### PR TITLE
ADD: GameMode, GameState, GameInstance, Spawner 추가

### DIFF
--- a/Source/Shooter/Private/GameModes/ShooterBaseGameMode.cpp
+++ b/Source/Shooter/Private/GameModes/ShooterBaseGameMode.cpp
@@ -1,5 +1,94 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿#include "GameModes/ShooterBaseGameMode.h"
+#include "GameModes/ShooterGameStateBase.h"
+#include "GameModes/Spawner.h"
+#include "GameModes/ShooterGameInstance.h"
+#include "Kismet/GameplayStatics.h"
+#include "Controllers/ShooterController.h"
+#include "Characters/ShooterCharacter.h"
 
+AShooterBaseGameMode::AShooterBaseGameMode()
+{
+	DefaultPawnClass = AShooterCharacter::StaticClass();
+	PlayerControllerClass = AShooterController::StaticClass();
+	GameStateClass = AShooterGameStateBase::StaticClass();
+}
 
-#include "GameModes/ShooterBaseGameMode.h"
+void AShooterBaseGameMode::StartPlay()
+{
+	Super::StartPlay();
 
+	GameInstance = Cast<UShooterGameInstance>(GetGameInstance());
+	if (GameInstance == nullptr)
+	{
+		UE_LOG(LogTemp, Error, TEXT("GameInstance not found!"));
+		return;
+	}
+
+	FString CurrentMapName = GetWorld()->GetMapName();
+	if (CurrentMapName.Contains("MenuLevel"))
+	{
+		GetWorldTimerManager().SetTimer(
+			StartTime,
+			this,
+			&AShooterBaseGameMode::StartGame,
+			3.0f,
+			false
+		);
+	}
+	else
+	{
+		StartWave();
+	}
+}
+
+void AShooterBaseGameMode::StartGame()
+{
+	GetWorldTimerManager().ClearTimer(StartTime);
+	GameInstance->NextWaveLevel();
+}
+
+void AShooterBaseGameMode::StartWave()
+{
+	GameInstance->CurrentWave++;
+	UE_LOG(LogTemp, Warning, TEXT("Wave %d Start"), GameInstance->CurrentWave);
+
+	TArray<AActor*> SpawnerActors;
+	UGameplayStatics::GetAllActorsOfClass(this, ASpawner::StaticClass(), SpawnerActors);
+
+	int32 TotalSpawnedEnemies = GameInstance->CurrentWave;
+
+	for (AActor* Actor : SpawnerActors)
+	{
+		if (ASpawner* Spawner = Cast<ASpawner>(Actor))
+		{
+			Spawner->SpawnEnemies(TotalSpawnedEnemies);
+		}
+	}
+
+	AShooterGameStateBase* GS = GetGameState<AShooterGameStateBase>();
+	if (GS)
+	{
+		GS->SetAliveEnemyCount(GameInstance->CurrentWave);
+	}
+}
+
+void AShooterBaseGameMode::OnAllEnemiesDefeated()
+{
+	if (GameInstance->CurrentWave >= GameInstance->MaxWave)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Clear all waves"));
+		EndGame(true);
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Clear wave %d"), GameInstance->CurrentWave);
+		GameInstance->NextWaveLevel();
+	}
+}
+
+void AShooterBaseGameMode::EndGame(bool bIsWin)
+{
+	UE_LOG(LogTemp, Warning, TEXT("End Game!!!"));
+	GameInstance->CurrentWave = 0;
+	//게임 종료 시 이겼나 졌나로 분기처리하여 플레이어에게 보여줄 화면?
+}

--- a/Source/Shooter/Private/GameModes/ShooterGameInstance.cpp
+++ b/Source/Shooter/Private/GameModes/ShooterGameInstance.cpp
@@ -1,0 +1,36 @@
+﻿#include "GameModes/ShooterGameInstance.h"
+#include "Kismet/GameplayStatics.h"
+
+UShooterGameInstance::UShooterGameInstance()
+{
+	MaxWave = 4;
+	CurrentWave = 0;
+}
+
+void UShooterGameInstance::Init()
+{
+	Super::Init();
+
+	if (WaveLevelNames.IsEmpty())
+	{
+		for (int32 i = 1; i <= MaxWave; ++i)
+		{
+			FString LevelName = FString::Printf(TEXT("Level%d"), i);
+			WaveLevelNames.Add(FName(*LevelName));
+		}
+	}
+}
+
+
+void UShooterGameInstance::NextWaveLevel()
+{
+	if (WaveLevelNames.IsValidIndex(CurrentWave))
+	{
+		UGameplayStatics::OpenLevel(GetWorld(), WaveLevelNames[CurrentWave]);
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Invalid wave index(-1): %d"), CurrentWave);
+	}
+}
+

--- a/Source/Shooter/Private/GameModes/ShooterGameStateBase.cpp
+++ b/Source/Shooter/Private/GameModes/ShooterGameStateBase.cpp
@@ -1,0 +1,29 @@
+﻿#include "GameModes/ShooterGameStateBase.h"
+#include "GameModes/ShooterBaseGameMode.h"
+
+AShooterGameStateBase::AShooterGameStateBase()
+{
+	TotalEnemy = 0;
+	AliveEnemyCount = 0;
+}
+
+void AShooterGameStateBase::SetAliveEnemyCount(int32 Count)
+{
+	TotalEnemy = Count;
+	AliveEnemyCount = TotalEnemy;
+}
+
+void AShooterGameStateBase::OnEnemyDied()
+{
+	AliveEnemyCount--;
+	UE_LOG(LogTemp, Warning, TEXT("The enemy is dead  (%d / %d)"), AliveEnemyCount, TotalEnemy);
+
+	if (AliveEnemyCount <= 0)
+	{
+		AShooterBaseGameMode* GameMode = GetWorld()->GetAuthGameMode<AShooterBaseGameMode>();
+		if (GameMode)
+		{
+			GameMode->OnAllEnemiesDefeated();
+		}
+	}
+}

--- a/Source/Shooter/Private/GameModes/Spawner.cpp
+++ b/Source/Shooter/Private/GameModes/Spawner.cpp
@@ -1,0 +1,51 @@
+﻿#include "GameModes/Spawner.h"
+#include "Components/BoxComponent.h"
+#include "tmp/TempC.h"
+
+
+ASpawner::ASpawner()
+{
+
+	PrimaryActorTick.bCanEverTick = false;
+
+	Scene = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
+	SetRootComponent(Scene);
+
+	SpawningBox = CreateDefaultSubobject<UBoxComponent>(TEXT("SpawningBox"));
+	SpawningBox->SetupAttachment(Scene);
+
+}
+
+void ASpawner::SpawnEnemies(int32 NumEnemies)
+{
+	if (!EnemyClass) return;
+
+	UWorld* World = GetWorld();
+	if (!World) return;
+
+	for (int32 i = 0; i < NumEnemies; ++i)
+	{
+		FVector SpawnLocation = GetRandomPointInVolume();
+		World->SpawnActor<ACharacter>(
+			EnemyClass,
+			SpawnLocation, 
+			FRotator::ZeroRotator
+			);
+	}
+
+	UE_LOG(LogTemp, Warning, TEXT("Enemy spawned :%d"), NumEnemies);
+}
+
+FVector ASpawner::GetRandomPointInVolume() const
+{
+	FVector BoxExtent = SpawningBox->GetScaledBoxExtent();
+	FVector BoxOrigin = SpawningBox->GetComponentLocation();
+
+	return BoxOrigin + FVector(
+		FMath::FRandRange(-BoxExtent.X, BoxExtent.X),
+		FMath::FRandRange(-BoxExtent.Y, BoxExtent.Y),
+		FMath::FRandRange(-BoxExtent.Z, BoxExtent.Z)
+	);
+}
+
+

--- a/Source/Shooter/Public/GameModes/ShooterBaseGameMode.h
+++ b/Source/Shooter/Public/GameModes/ShooterBaseGameMode.h
@@ -1,17 +1,30 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
-#pragma once
+﻿#pragma once
 
 #include "CoreMinimal.h"
 #include "GameFramework/GameModeBase.h"
 #include "ShooterBaseGameMode.generated.h"
 
-/**
- * 
- */
+class UShooterGameInstance;
+
 UCLASS()
 class SHOOTER_API AShooterBaseGameMode : public AGameModeBase
 {
 	GENERATED_BODY()
-	
+
+public:
+	AShooterBaseGameMode();
+	virtual void StartPlay() override;
+
+	UFUNCTION(BlueprintCallable)
+	void StartGame();
+	UFUNCTION(BlueprintCallable)
+	void StartWave();
+
+	void OnAllEnemiesDefeated();
+	void EndGame(bool bIsWin);
+
+private:
+	UShooterGameInstance* GameInstance;
+
+	FTimerHandle StartTime;
 };

--- a/Source/Shooter/Public/GameModes/ShooterGameInstance.h
+++ b/Source/Shooter/Public/GameModes/ShooterGameInstance.h
@@ -1,0 +1,28 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/GameInstance.h"
+#include "ShooterGameInstance.generated.h"
+
+UCLASS()
+class SHOOTER_API UShooterGameInstance : public UGameInstance
+{
+	GENERATED_BODY()
+	
+public:
+	UShooterGameInstance();
+	virtual void Init() override;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Wave")
+	int32 MaxWave;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Wave")
+	int32 CurrentWave;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Wave")
+	TArray<FName> WaveLevelNames;
+
+	UFUNCTION(BlueprintCallable)
+	void NextWaveLevel();
+
+};

--- a/Source/Shooter/Public/GameModes/ShooterGameStateBase.h
+++ b/Source/Shooter/Public/GameModes/ShooterGameStateBase.h
@@ -1,0 +1,26 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameStateBase.h"
+#include "ShooterGameStateBase.generated.h"
+
+UCLASS()
+class SHOOTER_API AShooterGameStateBase : public AGameStateBase
+{
+	GENERATED_BODY()
+
+public:
+	AShooterGameStateBase();
+
+	UPROPERTY(BlueprintReadOnly)
+	int32 AliveEnemyCount;
+
+	UPROPERTY(BlueprintReadOnly)
+	int32 TotalEnemy;
+
+	void SetAliveEnemyCount(int32 Count);
+
+	UFUNCTION(BlueprintCallable)
+	void OnEnemyDied();
+
+};

--- a/Source/Shooter/Public/GameModes/Spawner.h
+++ b/Source/Shooter/Public/GameModes/Spawner.h
@@ -1,0 +1,31 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "Spawner.generated.h"
+
+class UBoxComponent;
+
+UCLASS()
+class SHOOTER_API ASpawner : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	ASpawner();
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SpawnEnemy")
+	TSubclassOf<class ACharacter> EnemyClass;
+
+	void SpawnEnemies(int32 NumEnemies);
+
+protected:
+
+	UPROPERTY(VisibleAnywhere)
+	USceneComponent* Scene;
+
+	UPROPERTY(VisibleAnywhere)
+	UBoxComponent* SpawningBox;
+
+	FVector GetRandomPointInVolume() const;
+};


### PR DESCRIPTION
ShooterBaseGameMode
 - 게임 시작 로직 -- Spawner에게 Enemy 스폰 요청 -- ShooterGameStateBase에게 스폰된 Enemy 수 전달
 - 웨이브 클리어 로직
 - 게임 클리어 로직
 - GameInstance에게 레벨 전환 요청

ShooterGameInstance
 - 총 웨이브 수 와 현재 웨이브 정보
 - 레벨 전환 로직

ShooterGameStateBase
 - Spawner에서 스폰된 Enemy의 총 수와 현재 살아있는 Enemy의 수 정보
 - Enemy 사망 시 카운트 로직

Spawner
 - ShooterBaseGameMode에서 전달받은 수(Num)만큼 Enemy 스폰

------------------------------------------------------------------------------------------------------------

TODO
맵과 스폰관련 처리 
 - 맵 지정 (DataTable 사용하여 처리 할 예정)
 - 스폰될 actor 지정 (여러개 가능하도록) (DataTable 사용하여 처리 할 예정)
 - 스폰되는 위치 조정(z축) 

임시 Game Start 변경 필요
Game End 시 분기처리 부분