### PR TITLE
Add: ShooterEnemyCombatComponent 및 관련 전투 로직 추가

### DIFF
--- a/Content/PlayerCharacter/GamePlayAbility/DeathReact/GA_Shooter_DeathReact.uasset
+++ b/Content/PlayerCharacter/GamePlayAbility/DeathReact/GA_Shooter_DeathReact.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c69d33144a9891a3268ad8ee3ffdd7700750b59a0e8dcfeba8b533d62b8e946a
-size 76228
+oid sha256:3ffdba84d670f4a68c8ba03a6efee677b27011bc9e3d004deeb136171e377e33
+size 75883

--- a/Content/PlayerCharacter/GamePlayAbility/GA_ShooterGun.uasset
+++ b/Content/PlayerCharacter/GamePlayAbility/GA_ShooterGun.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0453951f80b2d0da7efdbcf9e8f447a3716a1fca94d54ee5fcbaf9a81bb5edcb
-size 22429
+oid sha256:cd1c2f3cc961638f325dbdb9710907e5854029a4165e206952f827e0f0877353
+size 22747

--- a/Content/PlayerCharacter/GamePlayAbility/HitReact/GA_Shooter_HitReact.uasset
+++ b/Content/PlayerCharacter/GamePlayAbility/HitReact/GA_Shooter_HitReact.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5a71ef25fb21d5b9200cbc4e177f3864483d298b5fb61b3eeb25ee41621a632
-size 87040
+oid sha256:d1625dfb9af7905911d564835e44cb105a3e84c42ebc491780ba478e04bd0381
+size 85884

--- a/Source/Shooter/Private/AbilitySystem/Abilities/ShooterEnemyGameplayAbility.cpp
+++ b/Source/Shooter/Private/AbilitySystem/Abilities/ShooterEnemyGameplayAbility.cpp
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "AbilitySystem/Abilities/ShooterEnemyGameplayAbility.h"
+#include "Characters/ShooterEnemyCharacter.h"
+
+AShooterEnemyCharacter* UShooterEnemyGameplayAbility::GetEnemyCharacterFromActorInfo()
+{
+	if (!CachedShooterEnemyCharacter.IsValid())
+	{
+		CachedShooterEnemyCharacter = Cast<AShooterEnemyCharacter>(CurrentActorInfo->AvatarActor);
+	}
+
+	return CachedShooterEnemyCharacter.IsValid() ? CachedShooterEnemyCharacter.Get() : nullptr;
+}
+
+UShooterEnemyCombatComponent* UShooterEnemyGameplayAbility::GetEnemyCombatComponentFromActorInfo()
+{
+	return GetEnemyCharacterFromActorInfo()->GetEnemyCombatComponent();
+}

--- a/Source/Shooter/Private/Characters/ShooterEnemyCharacter.cpp
+++ b/Source/Shooter/Private/Characters/ShooterEnemyCharacter.cpp
@@ -6,6 +6,7 @@
 #include "AbilitySystem/Abilities/ShooterGameplayAbility.h"
 #include "DataAssets/StartUpDatas/DataAsset_StartUpDataBase.h"
 #include "AIController.h"
+#include "Components/Combat/ShooterEnemyCombatComponent.h"
 
 AShooterEnemyCharacter::AShooterEnemyCharacter()
 {
@@ -16,12 +17,18 @@ AShooterEnemyCharacter::AShooterEnemyCharacter()
 	AutoPossessAI = EAutoPossessAI::PlacedInWorldOrSpawned;
 }
 
+UPawnCombatComponent* AShooterEnemyCharacter::GetPawnCombatComponent() const
+{
+	return ShooterEnemyCombatComponent;
+}
+
 void AShooterEnemyCharacter::BeginPlay()
 {
 	Super::BeginPlay();
 
 	ShooterAbilitySystemComponent->GetGameplayAttributeValueChangeDelegate(
-		ShooterAttributeSet->GetCurrentHealthAttribute()).AddUObject(this, &AShooterEnemyCharacter::OnHealthAttributeChanged);
+		ShooterAttributeSet->GetCurrentHealthAttribute()).AddUObject(
+		this, &AShooterEnemyCharacter::OnHealthAttributeChanged);
 
 	if (!CharacterStartUpData.IsNull())
 	{
@@ -35,7 +42,6 @@ void AShooterEnemyCharacter::BeginPlay()
 	float CurHealth = ShooterAttributeSet->GetCurrentHealth();
 	float MaxHealth = ShooterAttributeSet->GetMaxHealth();
 	UE_LOG(LogTemp, Warning, TEXT("CurHealth: %f / MaxHealth: %f"), CurHealth, MaxHealth);
-
 }
 
 void AShooterEnemyCharacter::OnHealthAttributeChanged(const FOnAttributeChangeData& Data)

--- a/Source/Shooter/Private/Components/Combat/ShooterEnemyCombatComponent.cpp
+++ b/Source/Shooter/Private/Components/Combat/ShooterEnemyCombatComponent.cpp
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Components/Combat/ShooterEnemyCombatComponent.h"
+#include "AbilitySystemBlueprintLibrary.h"
+
+void UShooterEnemyCombatComponent::TriggerGameplayEvent(
+	const FGameplayTag EventTag,
+	const FGameplayEventData& EventData
+)
+{
+	UAbilitySystemBlueprintLibrary::SendGameplayEventToActor(
+		GetOwningPawn(),
+		EventTag,
+		EventData
+	);
+}

--- a/Source/Shooter/Public/AbilitySystem/Abilities/ShooterEnemyGameplayAbility.h
+++ b/Source/Shooter/Public/AbilitySystem/Abilities/ShooterEnemyGameplayAbility.h
@@ -1,0 +1,28 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AbilitySystem/Abilities/ShooterGameplayAbility.h"
+#include "ShooterEnemyGameplayAbility.generated.h"
+
+class AShooterEnemyCharacter;
+class UShooterEnemyCombatComponent;
+
+/**
+ * 
+ */
+UCLASS()
+class SHOOTER_API UShooterEnemyGameplayAbility : public UShooterGameplayAbility
+{
+	GENERATED_BODY()
+
+
+	UFUNCTION(BlueprintPure, Category = "Shooter|Ability", meta = (AllowPrivateAccess = "true"))
+	AShooterEnemyCharacter* GetEnemyCharacterFromActorInfo();
+
+	UFUNCTION(BlueprintPure, Category = "Shooter|Ability", meta = (AllowPrivateAccess = "true"))
+	UShooterEnemyCombatComponent* GetEnemyCombatComponentFromActorInfo();
+
+	TWeakObjectPtr<AShooterEnemyCharacter> CachedShooterEnemyCharacter;
+};

--- a/Source/Shooter/Public/Characters/ShooterEnemyCharacter.h
+++ b/Source/Shooter/Public/Characters/ShooterEnemyCharacter.h
@@ -10,6 +10,7 @@
 
 class UDataAsset_InputConfig;
 class AAIController;
+class UShooterEnemyCombatComponent;
 /**
  *
  */
@@ -20,6 +21,9 @@ class SHOOTER_API AShooterEnemyCharacter : public AShooterBaseCharacter
 
 public:
 	AShooterEnemyCharacter();
+	//~ Begin IPawnCombatInterface Interface.
+	virtual UPawnCombatComponent* GetPawnCombatComponent() const override;
+	//~ End IPawnCombatInterface Interface.
 
 protected:
 	virtual void BeginPlay() override;
@@ -28,4 +32,10 @@ protected:
 
 	UFUNCTION(BlueprintImplementableEvent, Category = "GAS")
 	void OnHealthChanged(float OldValue, float NewValue);
+
+	UPROPERTY(VisibleDefaultsOnly, BlueprintReadOnly, Category = "Comnat")
+	UShooterEnemyCombatComponent* ShooterEnemyCombatComponent;
+
+public:
+	FORCEINLINE UShooterEnemyCombatComponent* GetEnemyCombatComponent() const { return ShooterEnemyCombatComponent; }
 };

--- a/Source/Shooter/Public/Components/Combat/ShooterEnemyCombatComponent.h
+++ b/Source/Shooter/Public/Components/Combat/ShooterEnemyCombatComponent.h
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Abilities/GameplayAbilityTypes.h"
+#include "Components/Combat/PawnCombatComponent.h"
+#include "ShooterEnemyCombatComponent.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class SHOOTER_API UShooterEnemyCombatComponent : public UPawnCombatComponent
+{
+	GENERATED_BODY()
+
+	// public, protected, private이 없으면 암묵적으로 "private" 화 됨
+	void TriggerGameplayEvent(const FGameplayTag EventTag, const FGameplayEventData& EventData);
+};

--- a/Source/Shooter/Public/ShooterGamePlayTag.h
+++ b/Source/Shooter/Public/ShooterGamePlayTag.h
@@ -32,6 +32,7 @@ namespace ShooterGamePlayTags
 	/* Shared */
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Ability_Death);
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Ability_HitReact);
+	
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Status_HitReact_Front);
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Status_HitReact_Left);
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Status_HitReact_Back);

--- a/Source/Shooter/Shooter.Build.cs
+++ b/Source/Shooter/Shooter.Build.cs
@@ -17,7 +17,8 @@ public class Shooter : ModuleRules
 			"EnhancedInput",
 			"GameplayTags",
 			"GameplayTasks",
-			"AIModule"
+			"AIModule",
+			"GameplayAbilities"
 		});
 
 		PrivateDependencyModuleNames.AddRange(new string[] { });


### PR DESCRIPTION
`UShooterEnemyCombatComponent`를 도입하여 적 전용 전투 기능을 처리하도록 했습니다.
`AShooterEnemyCharacter`를 업데이트하여 새로운 컴포넌트를 통합하고 관련 메서드를 외부에 노출했습니다.
`UShooterEnemyGameplayAbility`를 추가하여 적 전용 기능을 능력 시스템에 확장하고, 이에 따라 의존성도 리팩터링했습니다.