### PR TITLE
Add: Player Health & Weapon Ammo UI 구현

### DIFF
--- a/Content/UI/BP_ShooterHUD.uasset
+++ b/Content/UI/BP_ShooterHUD.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5a50e069cf762264e86245480166e48c1c073576cbff1548f98870dd6335217
-size 55470
+oid sha256:db8f0dbab7cecd1e9720fe89002183bcb4e40bd8d36dcabe596c7d1e351e419a
+size 77976

--- a/Content/UI/BP_ShooterHUD.uasset
+++ b/Content/UI/BP_ShooterHUD.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5a50e069cf762264e86245480166e48c1c073576cbff1548f98870dd6335217
+size 55470

--- a/Content/UI/WBP_PlayerHealth.uasset
+++ b/Content/UI/WBP_PlayerHealth.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53671a207e1706e3b96740c873cc77f09d75c5a9549acd86a0c1c6f56651ea0c
+size 37772

--- a/Content/UI/WBP_WeaponAmmo.uasset
+++ b/Content/UI/WBP_WeaponAmmo.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c49cff96f416579626b266c6ae80b1267a5d4c272332a0f501ba13ebea64386
+size 49832

--- a/Source/Shooter/Private/AbilitySystem/ShooterAttributeSet.cpp
+++ b/Source/Shooter/Private/AbilitySystem/ShooterAttributeSet.cpp
@@ -2,6 +2,8 @@
 
 
 #include "AbilitySystem/ShooterAttributeSet.h"
+#include "GameplayEffectExtension.h"
+#include "Components/UI/PawnUIComponent.h"
 
 UShooterAttributeSet::UShooterAttributeSet()
 {
@@ -15,4 +17,18 @@ UShooterAttributeSet::UShooterAttributeSet()
 void UShooterAttributeSet::PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data)
 {
 	// TODO: ui 변경에 대한 로직 작성 필요
+    if (Data.EvaluatedData.Attribute == GetCurrentHealthAttribute())
+    {
+        float NewPercent = GetCurrentHealth() / GetMaxHealth();
+        // Actor 소유자 가져오기
+        AActor* OwnerActor = GetOwningActor();
+        if (!OwnerActor) return;
+
+        // UI 컴포넌트 가져오기
+        UPawnUIComponent* UIComponent = OwnerActor->FindComponentByClass<UPawnUIComponent>();
+        if (!UIComponent) return;
+
+        // 체력 변경 알림 보내기
+        UIComponent->HandleCurrentHealthChanged(NewPercent);
+    }
 }

--- a/Source/Shooter/Private/Components/UI/PawnUIComponent.cpp
+++ b/Source/Shooter/Private/Components/UI/PawnUIComponent.cpp
@@ -1,5 +1,12 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 
 #include "Components/UI/PawnUIComponent.h"
 
+void UPawnUIComponent::HandleCurrentHealthChanged(float NewPercent)
+{
+    UE_LOG(LogTemp, Log, TEXT("[PawnUIComponent] 체력 변경 감지: %.2f"), NewPercent);
+
+    // HUD 위젯에 알리기 위해 브로드캐스트
+    OnCurrentHealthChanged.Broadcast(NewPercent);
+}

--- a/Source/Shooter/Private/Components/UI/ShooterUIComponent.cpp
+++ b/Source/Shooter/Private/Components/UI/ShooterUIComponent.cpp
@@ -1,5 +1,12 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 
 #include "Components/UI/ShooterUIComponent.h"
 
+void UShooterUIComponent::HandleCurrentAmmoChanged(float NewAmmo)
+{
+    UE_LOG(LogTemp, Log, TEXT("[ShooterUIComponent] 총알 변경 감지: %.2f"), NewAmmo);
+
+    // HUD 위젯에 알리기 위해 브로드캐스트
+    OnCurrentAmmoChanged.Broadcast(NewAmmo);
+}

--- a/Source/Shooter/Private/Items/Weapons/WeaponAttributeSet.cpp
+++ b/Source/Shooter/Private/Items/Weapons/WeaponAttributeSet.cpp
@@ -2,10 +2,37 @@
 
 
 #include "Items/Weapons/WeaponAttributeSet.h"
+#include "GameplayEffectExtension.h"
+#include "Components/UI/ShooterUIComponent.h"
 
 UWeaponAttributeSet::UWeaponAttributeSet()
 {
     InitMaxAmmo(30.f);
     InitCurrentAmmo(GetMaxAmmo());
+}
+
+void UWeaponAttributeSet::PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data)
+{
+    if (Data.EvaluatedData.Attribute == GetCurrentAmmoAttribute())
+    {
+        float NewAmmo = GetCurrentAmmo();
+
+        // Actor 소유자 가져오기
+        AActor* OwnerActor = GetOwningActor();
+        if (!OwnerActor)
+        {
+            return;
+        }
+
+        // UI 컴포넌트 가져오기
+        UShooterUIComponent* UIComponent = OwnerActor->FindComponentByClass<UShooterUIComponent>();
+        if (!UIComponent)
+        {
+            return;
+        }
+
+        // 총알 변경 알림 보내기
+        UIComponent->HandleCurrentAmmoChanged(NewAmmo);
+    }
 }
 

--- a/Source/Shooter/Public/Components/UI/PawnUIComponent.h
+++ b/Source/Shooter/Public/Components/UI/PawnUIComponent.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
@@ -18,4 +18,6 @@ class SHOOTER_API UPawnUIComponent : public UPawnExtensionComponentBase
 
 	UPROPERTY(BlueprintAssignable)
 	FOnPercentChangedDelegate OnCurrentHealthChanged;
+public:
+	void HandleCurrentHealthChanged(float NewPercent);
 };

--- a/Source/Shooter/Public/Components/UI/ShooterUIComponent.h
+++ b/Source/Shooter/Public/Components/UI/ShooterUIComponent.h
@@ -1,10 +1,12 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
 #include "CoreMinimal.h"
 #include "Components/UI/PawnUIComponent.h"
 #include "ShooterUIComponent.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnAmmoChangedDelegate, float, NewAmmo);
 
 /**
  * 
@@ -13,5 +15,9 @@ UCLASS()
 class SHOOTER_API UShooterUIComponent : public UPawnUIComponent
 {
 	GENERATED_BODY()
-	
+
+	UPROPERTY(BlueprintAssignable)
+	FOnAmmoChangedDelegate  OnCurrentAmmoChanged;
+public:
+	void HandleCurrentAmmoChanged(float NewAmmo);
 };

--- a/Source/Shooter/Public/Items/Weapons/WeaponAttributeSet.h
+++ b/Source/Shooter/Public/Items/Weapons/WeaponAttributeSet.h
@@ -17,6 +17,8 @@ class SHOOTER_API UWeaponAttributeSet : public UShooterAttributeSet
 public:
     UWeaponAttributeSet();
 
+    void PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data) override;
+
     // 최대 탄약 수
     UPROPERTY(BlueprintReadOnly, Category = "Weapon")
     FGameplayAttributeData MaxAmmo;


### PR DESCRIPTION
PlayerHealth UI (WBP_PlayerHealth)
- Progress Bar를 통해 플레이어 체력을 시각화
- UpdateHealthBar 이벤트에서 체력 비율 반영
- BP_ShooterHUD에서 OnCurrentHealthChanged 바인딩하여 자동 갱신

 WeaponAmmo UI(WBP_WeaponAmmo)
- 플레이어의 CurrentAmmo 값을 실시간으로 표시하는 위젯 추가
- Update CurrentAmmo Text 이벤트로 개수 반영
- 마찬가지로 바인딩하여 자동 갱신

[테스트 영상](https://drive.google.com/file/d/1fiCYzLAqx6NvyyVOvaEgU6bATjSKU8Mw/view?usp=sharing)