### PR TITLE
Add: 무기 능력, 피해 계산, 게임플레이 태그 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ Saved/
 *.ipch
 /Content/Asset
 /Content/Temp
+/Content/Assets
+/Content/ThirdPerson
+/Content/__ExternalActors__
+/Content/__ExternalObjects__
+/Content/Mpas/Lvl_ThirdPerson.umap
+/Content/PlayerCharacter/AnimationBP

--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -1,96 +1,95 @@
-
-
 [/Script/EngineSettings.GameMapsSettings]
-GameDefaultMap=/Game/Mpas/Lvl_ThirdPerson.Lvl_ThirdPerson
-EditorStartupMap=/Game/Mpas/Lvl_ThirdPerson.Lvl_ThirdPerson
+GameDefaultMap = /Game/Mpas/Lvl_ThirdPerson.Lvl_ThirdPerson
+EditorStartupMap = /Game/Mpas/Lvl_ThirdPerson.Lvl_ThirdPerson
 
 [/Script/Engine.RendererSettings]
-r.AllowStaticLighting=False
+r.AllowStaticLighting = False
 
-r.GenerateMeshDistanceFields=True
+r.GenerateMeshDistanceFields = True
 
-r.DynamicGlobalIlluminationMethod=1
+r.DynamicGlobalIlluminationMethod = 1
 
-r.ReflectionMethod=1
+r.ReflectionMethod = 1
 
-r.SkinCache.CompileShaders=True
+r.SkinCache.CompileShaders = True
 
-r.RayTracing.RayTracingProxies.ProjectEnabled=True
+r.RayTracing.RayTracingProxies.ProjectEnabled = True
 
-r.Shadow.Virtual.Enable=1
+r.Shadow.Virtual.Enable = 1
 
-r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange=True
+r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange = True
 
-r.DefaultFeature.LocalExposure.HighlightContrastScale=0.8
+r.DefaultFeature.LocalExposure.HighlightContrastScale = 0.8
 
-r.DefaultFeature.LocalExposure.ShadowContrastScale=0.8
+r.DefaultFeature.LocalExposure.ShadowContrastScale = 0.8
 
 [/Script/WindowsTargetPlatform.WindowsTargetSettings]
-DefaultGraphicsRHI=DefaultGraphicsRHI_DX12
-DefaultGraphicsRHI=DefaultGraphicsRHI_DX12
--D3D12TargetedShaderFormats=PCD3D_SM5
-+D3D12TargetedShaderFormats=PCD3D_SM6
--D3D11TargetedShaderFormats=PCD3D_SM5
-+D3D11TargetedShaderFormats=PCD3D_SM5
-Compiler=Default
-AudioSampleRate=48000
-AudioCallbackBufferFrameSize=1024
-AudioNumBuffersToEnqueue=1
-AudioMaxChannels=0
-AudioNumSourceWorkers=4
-SpatializationPlugin=
-SourceDataOverridePlugin=
-ReverbPlugin=
-OcclusionPlugin=
-CompressionOverrides=(bOverrideCompressionTimes=False,DurationThreshold=5.000000,MaxNumRandomBranches=0,SoundCueQualityIndex=0)
-CacheSizeKB=65536
-MaxChunkSizeOverrideKB=0
-bResampleForDevice=False
-MaxSampleRate=48000.000000
-HighSampleRate=32000.000000
-MedSampleRate=24000.000000
-LowSampleRate=12000.000000
-MinSampleRate=8000.000000
-CompressionQualityModifier=1.000000
-AutoStreamingThreshold=0.000000
-SoundCueCookQualityIndex=-1
+DefaultGraphicsRHI = DefaultGraphicsRHI_DX12
+DefaultGraphicsRHI = DefaultGraphicsRHI_DX12
+-D3D12TargetedShaderFormats = PCD3D_SM5
++D3D12TargetedShaderFormats = PCD3D_SM6
+-D3D11TargetedShaderFormats = PCD3D_SM5
++D3D11TargetedShaderFormats = PCD3D_SM5
+Compiler = Default
+AudioSampleRate = 48000
+AudioCallbackBufferFrameSize = 1024
+AudioNumBuffersToEnqueue = 1
+AudioMaxChannels = 0
+AudioNumSourceWorkers = 4
+SpatializationPlugin =
+SourceDataOverridePlugin =
+ReverbPlugin =
+OcclusionPlugin =
+CompressionOverrides = (bOverrideCompressionTimes=False,DurationThreshold=5.000000,MaxNumRandomBranches=0,SoundCueQualityIndex=0)
+CacheSizeKB = 65536
+MaxChunkSizeOverrideKB = 0
+bResampleForDevice = False
+MaxSampleRate = 48000.000000
+HighSampleRate = 32000.000000
+MedSampleRate = 24000.000000
+LowSampleRate = 12000.000000
+MinSampleRate = 8000.000000
+CompressionQualityModifier = 1.000000
+AutoStreamingThreshold = 0.000000
+SoundCueCookQualityIndex = -1
 
 [/Script/LinuxTargetPlatform.LinuxTargetSettings]
--TargetedRHIs=SF_VULKAN_SM5
-+TargetedRHIs=SF_VULKAN_SM6
+-TargetedRHIs = SF_VULKAN_SM5
++TargetedRHIs = SF_VULKAN_SM6
 
 [/Script/HardwareTargeting.HardwareTargetingSettings]
-TargetedHardwareClass=Desktop
-AppliedTargetedHardwareClass=Desktop
-DefaultGraphicsPerformance=Maximum
-AppliedDefaultGraphicsPerformance=Maximum
+TargetedHardwareClass = Desktop
+AppliedTargetedHardwareClass = Desktop
+DefaultGraphicsPerformance = Maximum
+AppliedDefaultGraphicsPerformance = Maximum
 
 [/Script/WorldPartitionEditor.WorldPartitionEditorSettings]
-CommandletClass=Class'/Script/UnrealEd.WorldPartitionConvertCommandlet'
+CommandletClass = Class'/Script/UnrealEd.WorldPartitionConvertCommandlet'
 
 [/Script/Engine.UserInterfaceSettings]
-bAuthorizeAutomaticWidgetVariableCreation=False
-FontDPIPreset=Standard
-FontDPI=72
+bAuthorizeAutomaticWidgetVariableCreation = False
+FontDPIPreset = Standard
+FontDPI = 72
 
 [/Script/Engine.Engine]
-+ActiveGameNameRedirects=(OldGameName="TP_Blank",NewGameName="/Script/Shooter")
-+ActiveGameNameRedirects=(OldGameName="/Script/TP_Blank",NewGameName="/Script/Shooter")
++ActiveGameNameRedirects = (OldGameName="TP_Blank",NewGameName="/Script/Shooter")
++ActiveGameNameRedirects = (OldGameName="/Script/TP_Blank",NewGameName="/Script/Shooter")
 
 [/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings]
-bEnablePlugin=True
-bAllowNetworkConnection=True
-SecurityToken=3483649E44FB192C37CFB1858BAD6A12
-bIncludeInShipping=False
-bAllowExternalStartInShipping=False
-bCompileAFSProject=False
-bUseCompression=False
-bLogFiles=False
-bReportStats=False
-ConnectionType=USBOnly
-bUseManualIPAddress=False
-ManualIPAddress=
+bEnablePlugin = True
+bAllowNetworkConnection = True
+SecurityToken = 3483649E44FB192C37CFB1858BAD6A12
+bIncludeInShipping = False
+bAllowExternalStartInShipping = False
+bCompileAFSProject = False
+bUseCompression = False
+bLogFiles = False
+bReportStats = False
+ConnectionType = USBOnly
+bUseManualIPAddress = False
+ManualIPAddress =
 
 
 [CoreRedirects]
-+ClassRedirects=(OldName="/Script/Shooter.ShooterConroller",NewName="/Script/Shooter.ShooterController")
++ClassRedirects = (OldName="/Script/Shooter.ShooterConroller",NewName="/Script/Shooter.ShooterController")
++StructRedirects = (OldName="/Script/Shooter.WarriorHeroWeaponData",NewName="/Script/Shooter.ShooterPlayerWeaponData")

--- a/Content/GameModes/BP_ShooterBaseGameMode.uasset
+++ b/Content/GameModes/BP_ShooterBaseGameMode.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3a39b7b99ce9dec6ebda656959de19bf5b7b0a97483249f02bc6ea6d0da5fe5
+size 21643

--- a/Content/PlayerCharacter/AS_WeaponAttributeSet.uasset
+++ b/Content/PlayerCharacter/AS_WeaponAttributeSet.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fb69f450d9e20a7a036affae659d885253dafa88e301373023b3cb50b443374
+size 6050

--- a/Content/PlayerCharacter/BP_ShooterCharacter.uasset
+++ b/Content/PlayerCharacter/BP_ShooterCharacter.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de6c2994ce88ad9614a2b780dc18419eac442224383e0a57a5cd2600045c25ed
+size 39578

--- a/Content/PlayerCharacter/BP_ShooterWeaponBase.uasset
+++ b/Content/PlayerCharacter/BP_ShooterWeaponBase.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edb7079692c467c1ce052b84a40689a7982211fbab2ba763027998286662426e
+size 24771

--- a/Content/PlayerCharacter/DA_InputConfig.uasset
+++ b/Content/PlayerCharacter/DA_InputConfig.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36daf474ca5086e6297f858981d7122dfb17f3fad789286b1ef7e24a9212b0c3
-size 4199
+oid sha256:b9c6821ff8b0eb95698a8f5349477fdc227f0e4dabf1e09acf1c6eb2824b6363
+size 4618

--- a/Content/PlayerCharacter/DA_ShooterStartup.uasset
+++ b/Content/PlayerCharacter/DA_ShooterStartup.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1f4145ab218da50c302e88ed05d26eec1d933ce6ee364d175fa36973ec4289a
-size 2646
+oid sha256:dc71a6e8db143358728e7617463b71b90f34a1e1f84bcb34f5502e133c3c55a8
+size 3421

--- a/Content/PlayerCharacter/GamePlayAbility/Fire/GA_Shooter_Fire.uasset
+++ b/Content/PlayerCharacter/GamePlayAbility/Fire/GA_Shooter_Fire.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb4be3fdbfc87b5f3799675a3a058690646d1c3e382446f408ae622744485848
+size 21963

--- a/Content/PlayerCharacter/GamePlayAbility/GA_EquipWeapon.uasset
+++ b/Content/PlayerCharacter/GamePlayAbility/GA_EquipWeapon.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7aaed0ec9d4d213afee647937702feea4f2d7cb9e6dc44ad9df425714d707427
-size 43984

--- a/Content/PlayerCharacter/GamePlayAbility/GA_ShooterGun.uasset
+++ b/Content/PlayerCharacter/GamePlayAbility/GA_ShooterGun.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd1c2f3cc961638f325dbdb9710907e5854029a4165e206952f827e0f0877353
-size 22747

--- a/Content/PlayerCharacter/GamePlayAbility/GA_Shooter_Equip_Weapon.uasset
+++ b/Content/PlayerCharacter/GamePlayAbility/GA_Shooter_Equip_Weapon.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a812124035ddb3b4739a9455c23fa49f779c2ae31ebe25960fa48159362e80d4
+size 150643

--- a/Content/PlayerCharacter/GamePlayAbility/GA_Shooter_Spawn_Weapon.uasset
+++ b/Content/PlayerCharacter/GamePlayAbility/GA_Shooter_Spawn_Weapon.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:764be39c69c16f797a6a264bdfc6164f86bf00539e76038dbdcd678fc87982d3
+size 22686

--- a/Content/PlayerCharacter/GamePlayAbility/GA_WeaponFire.uasset
+++ b/Content/PlayerCharacter/GamePlayAbility/GA_WeaponFire.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29926534caa33555433a75dad13dde5749ad3fd48eb37968ba3f2b8052860fd7
-size 217904
+oid sha256:a99e188558b87f6a7c39f98074bb425eb00a1726d8c78cef158e556a4ff741a7
+size 214164

--- a/Content/PlayerCharacter/GamePlayAbility/GE_TakeDamage.uasset
+++ b/Content/PlayerCharacter/GamePlayAbility/GE_TakeDamage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1bf28a3fdf3d9658c3352a9da789a8645b44a5401b47128cc682df1fb36f850
+size 7112

--- a/Content/PlayerCharacter/GamePlayAbility/Overlay/GA_Shooter_Draw_OverlayWidget.uasset
+++ b/Content/PlayerCharacter/GamePlayAbility/Overlay/GA_Shooter_Draw_OverlayWidget.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df937df1d12a0468f00d92962a1486661a06b40634906481c1723ade04d4e652
+size 21169

--- a/Content/PlayerCharacter/GamePlayEffect/GE_TakeDamage.uasset
+++ b/Content/PlayerCharacter/GamePlayEffect/GE_TakeDamage.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcc051e32a2ac81a3080513029c4180d91f20d06f03b18a04f87bd887f68c68a
-size 7087

--- a/Content/PlayerCharacter/Input/Actions/IA_Equip.uasset
+++ b/Content/PlayerCharacter/Input/Actions/IA_Equip.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89473f346e68aadb3d7ad1c852258a7f93cd1c793e2ecb8f05e5d745d0903d06
+size 1732

--- a/Content/PlayerCharacter/Input/Actions/IA_Shoot.uasset
+++ b/Content/PlayerCharacter/Input/Actions/IA_Shoot.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a6501d08a79cfd2a7bd187304ce2df30f20a1c707558c8362cba99cd1498cb4
+size 1226

--- a/Content/PlayerCharacter/Input/Actions/IA_Unequip.uasset
+++ b/Content/PlayerCharacter/Input/Actions/IA_Unequip.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81cba1352affd0ebec7195a17a4d4e1fc2b12fa51b76bb3cf51ff89027b162a5
+size 1742

--- a/Content/PlayerCharacter/Input/IMC_Default.uasset
+++ b/Content/PlayerCharacter/Input/IMC_Default.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d245e051a211d1140af0006c6a6eefdade79853d26da13249e515965c0d0d78a
-size 10043
+oid sha256:d4f7ee20a8e882f5a5b32fe7ee287ef798d73f79b076f729a3db1c4d5dd8d675
+size 10524

--- a/Content/PlayerCharacter/Input/IMC_Weapon.uasset
+++ b/Content/PlayerCharacter/Input/IMC_Weapon.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7828cef222366e90123586254dec3331bde18c1b9afe50eeac16104f199a867c
+size 2260

--- a/Content/PlayerCharacter/Weapon/BP_ShooterRifle.uasset
+++ b/Content/PlayerCharacter/Weapon/BP_ShooterRifle.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72bdf0b695fcc1dd655e26a66388ec02fa8c292595d3c38c199f5853d920cb3d
+size 45974

--- a/Content/PlayerCharacter/Weapon/BP_ShooterWeaponBase.uasset
+++ b/Content/PlayerCharacter/Weapon/BP_ShooterWeaponBase.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49dad7e935b4ff41a6dc28f3eeb676a08dac7f77a100be784835969673698bf4
-size 32968

--- a/Content/PlayerCharacter/Weapon/BP_ShooterWeaponRifle.uasset
+++ b/Content/PlayerCharacter/Weapon/BP_ShooterWeaponRifle.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e3e609778152c744e6a21cee63283958bc79e3b7c69849606125a612d1945b2c
-size 28180

--- a/Content/Shared/AnimNotify/AN_SendGameplayEvent.uasset
+++ b/Content/Shared/AnimNotify/AN_SendGameplayEvent.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:514de2633da0229e062b05974ca217eb8d17a4f07ae9e5507ba3755cf8d7ce74
+size 39173

--- a/Content/Shared/GA_Shared_Spawn_Weapon_Base.uasset
+++ b/Content/Shared/GA_Shared_Spawn_Weapon_Base.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8e65000c231d49ea9e380ed8a5861d033b048944bc5dd523f981584dca57556
-size 65242
+oid sha256:bef7535214eaa657288ac0c26fce757c2a867a037221e009ecf6b6ec7e3e5feb
+size 76771

--- a/Content/Shared/GA_ShootAttackMaster.uasset
+++ b/Content/Shared/GA_ShootAttackMaster.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6236411c91ae516406905aa64f02de87a6160e6ac04695b215ffc1207adf59c
+size 127657

--- a/Content/Shared/GameplayEffect/GE_Shared_DealDamage.uasset
+++ b/Content/Shared/GameplayEffect/GE_Shared_DealDamage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e060cf23cb5296447686ab75137cc98231fd3eef06b2943755d3ae4a3207fb46
+size 7028

--- a/Source/Shooter/Private/AbilitySystem/Abilities/ShooterGameplayAbility.cpp
+++ b/Source/Shooter/Private/AbilitySystem/Abilities/ShooterGameplayAbility.cpp
@@ -2,8 +2,17 @@
 
 
 #include "AbilitySystem/Abilities/ShooterGameplayAbility.h"
+#include "AbilitySystemBlueprintLibrary.h"
 #include "AbilitySystemComponent.h"
+#include "AbilitySystem/ShooterAbilitySystemComponent.h"
+#include "Components/Combat/PawnCombatComponent.h"
 
+
+/**
+ * 이 어빌리티가 액터(예: 캐릭터)에게 부여될 때 호출됨
+ * @param ActorInfo    어빌리티가 부여된 액터에 대한 정보
+ * @param Spec         어빌리티의 사양(레벨, 입력 바인딩 등)을 담고 있는 구조체
+ */
 void UShooterGameplayAbility::OnGiveAbility(
 	const FGameplayAbilityActorInfo* ActorInfo,
 	const FGameplayAbilitySpec& Spec
@@ -20,6 +29,18 @@ void UShooterGameplayAbility::OnGiveAbility(
 	}
 }
 
+/**
+ * 능력이 종료될 때 호출되는 함수.
+ * 
+ * 이 함수는 능력의 정상 종료 또는 취소 시 호출되며, 부모 클래스의 EndAbility를 호출한 뒤
+ * 특정 활성화 정책(EShooterAbilityActivationPolicy::EWA_OnGiven)에 따라 능력을 시스템에서 제거할 수 있음.
+ * 
+ * @param Handle                종료되는 능력의 핸들.
+ * @param ActorInfo             능력을 소유한 액터에 대한 정보.
+ * @param ActivationInfo        능력의 활성화 상태 정보.
+ * @param bReplicateEndAbility  이 종료 동작을 네트워크에 복제할지에 대한 여부.
+ * @param bWasCancelled         능력이 취소되어 종료되었는지 여부.
+ */
 void UShooterGameplayAbility::EndAbility(
 	const FGameplayAbilitySpecHandle Handle,
 	const FGameplayAbilityActorInfo* ActorInfo,
@@ -36,4 +57,78 @@ void UShooterGameplayAbility::EndAbility(
 			ActorInfo->AbilitySystemComponent->ClearAbility(Handle);
 		}
 	}
+}
+
+UPawnCombatComponent* UShooterGameplayAbility::GetPawnCombatComponentFromActorInfo() const
+{
+	return GetAvatarActorFromActorInfo()->FindComponentByClass<UPawnCombatComponent>();
+}
+
+/**
+ * 지정된 대상 액터에게 준비된 GameplayEffectSpec을 적용
+ *
+ * 이 함수는 대상 액터의 AbilitySystemComponent(ASC)를 가져오고,
+ * 전달된 GameplayEffectSpecHandle이 유효한지 확인한 뒤,
+ * 현재 능력의 ASC를 통해 대상에게 효과를 적용
+ *
+ * @param TargetActor         효과를 적용할 대상 액터
+ * @param InSpecHandle        적용할 준비된 GameplayEffectSpec을 담고 있는 핸들
+ * @return                    적용된 액티브 효과의 핸들
+ */
+FActiveGameplayEffectHandle UShooterGameplayAbility::NativeApplyEffectSpecHandleToTarget(AActor* TargetActor,
+	const FGameplayEffectSpecHandle& InSpecHandle)
+{
+	UAbilitySystemComponent* TargetASC = UAbilitySystemBlueprintLibrary::GetAbilitySystemComponent(TargetActor);
+
+	check(TargetASC && InSpecHandle.IsValid());
+
+	// !!타겟에게 적용
+	return GetShooterAbilitySystemComponentFromActorInfo()->ApplyGameplayEffectSpecToTarget(
+		*InSpecHandle.Data, // 핸들에서 실제 효과 사양(Spec)을 가져옴
+		TargetASC // 대상의 ASC
+	);
+}
+
+/**
+ * 현재 능력을 실행 중인 액터의 AbilitySystemComponent를 가져와서
+ * UShooterAbilitySystemComponent 타입으로 캐스팅하여 반환
+ *
+ * 이 함수는 Shooter 전용 AbilitySystemComponent가 필요할 때 사용
+ * (예: 공통 ASC가 아닌 Shooter에 특화된 기능을 사용할 경우)
+ *
+ * @return Shooter 전용 AbilitySystemComponent (UShooterAbilitySystemComponent*) 포인터
+ */
+UShooterAbilitySystemComponent* UShooterGameplayAbility::GetShooterAbilitySystemComponentFromActorInfo() const
+{
+	return Cast<UShooterAbilitySystemComponent>(CurrentActorInfo->AbilitySystemComponent);
+}
+
+/**
+ * 지정된 타겟 액터에게 GameplayEffectSpecHandle을 적용하고, 그 결과에 따라 성공 여부를 반환
+ * 
+ * 이 함수는 블루프린트에서 호출 가능한 래퍼 함수이며, 내부적으로 NativeApplyEffectSpecHandleToTarget을 호출하여
+ * 실제 효과를 적용
+ * 
+ * 적용 결과는 OutSuccessType에 저장되며, 적용 성공 여부를 ESC_Successful 또는 ESC_Failed로 나타냅
+ *
+ * @param TargetActor       효과를 적용할 대상 액터.
+ * @param InSpecHandle      적용할 GameplayEffect의 사양 핸들.
+ * @param OutSuccessType    효과 적용의 성공 여부가 저장. (성공 시 ESC_Successful, 실패 시 ESC_Failed)
+ * 
+ * @return FActiveGameplayEffectHandle  적용된 효과의 핸들을 반환. (실패 시 Invalid 핸들일 수 있음)
+ */
+FActiveGameplayEffectHandle UShooterGameplayAbility::BP_ApplyEffectSpecHandleToTarget(AActor* TargetActor,
+	const FGameplayEffectSpecHandle& InSpecHandle, EShooterSuccessType& OutSuccessType)
+{
+	FActiveGameplayEffectHandle ActiveGameplayEffectHandle = NativeApplyEffectSpecHandleToTarget(
+		TargetActor,
+		InSpecHandle
+	);
+
+	OutSuccessType =
+		ActiveGameplayEffectHandle.WasSuccessfullyApplied()
+			? EShooterSuccessType::ESC_Successful
+			: EShooterSuccessType::ESC_Failed;
+
+	return ActiveGameplayEffectHandle;
 }

--- a/Source/Shooter/Private/AbilitySystem/Abilities/ShooterPlayerGameplayAbility.cpp
+++ b/Source/Shooter/Private/AbilitySystem/Abilities/ShooterPlayerGameplayAbility.cpp
@@ -2,6 +2,9 @@
 
 
 #include "AbilitySystem/Abilities/ShooterPlayerGameplayAbility.h"
+
+#include "ShooterGamePlayTag.h"
+#include "AbilitySystem/ShooterAbilitySystemComponent.h"
 #include "Characters/ShooterCharacter.h"
 #include "Controllers/ShooterController.h"
 
@@ -44,4 +47,52 @@ UShooterCombatComponent* UShooterPlayerGameplayAbility::GetShooterCombatComponen
 {
 	const AShooterCharacter* ShooterCharacter = GetShooterCharacterFromActorInfo();
 	return ShooterCharacter ? ShooterCharacter->GetShooterCombatComponent() : nullptr;
+}
+
+/**
+ * - 지정된 GameplayEffect 클래스와 입력 정보를 바탕으로 FGameplayEffectSpecHandle을 생성
+ * - 이 함수는 무기의 기본 데미지와 현재 공격 상태(공격 태그, 콤보 수 등)를 SetByCaller 값으로 전달
+ * - 생성된 SpecHandle은 대상에게 이펙트를 적용할 때 사용
+ *
+ * @param EffectClass 적용할 GameplayEffect 클래스 (예: 데미지 이펙트)
+ * @param InWeaponBaseDamage 무기의 기본 데미지 수치 (SetByCaller로 전달)
+ * @param InCurrentAttackTypeTag 현재 공격 타입을 나타내는 태그 (예: 공격1, 차지공격 등)
+ * @param InUsedComboCount 현재 콤보 수치 (SetByCaller로 전달)
+ * @return 구성된 FGameplayEffectSpecHandle 인스턴스
+ */
+FGameplayEffectSpecHandle UShooterPlayerGameplayAbility::MakeShooterDamageEffectSpecHandle(
+	TSubclassOf<UGameplayEffect> EffectClass,
+	float InWeaponBaseDamage,
+	FGameplayTag InCurrentAttackTypeTag
+)
+{
+	check(EffectClass);
+
+	// 이펙트에 사용될 컨텍스트 핸들 생성 (누가 시전했는지, 어떤 스킬인지 등 정보를 담음)
+	FGameplayEffectContextHandle ContextHandle = GetShooterAbilitySystemComponentFromActorInfo()->MakeEffectContext();
+
+	// Ability 정보 추가 (누가 발동했는지)
+	ContextHandle.SetAbility(this);
+
+	// SourceObject 설정: 일반적으로 무기, 액터 등 이펙트의 "출처" 객체
+	ContextHandle.AddSourceObject(GetAvatarActorFromActorInfo());
+
+	ContextHandle.AddInstigator(GetAvatarActorFromActorInfo(), GetAvatarActorFromActorInfo());
+
+	// !!실제 GameplayEffect 사양을 생성함 실제 적용은 안되는단계 (어떤 효과를 어떤 레벨로 누구에게 적용할지)
+	FGameplayEffectSpecHandle EffectSpecHandle = GetShooterAbilitySystemComponentFromActorInfo()->MakeOutgoingSpec(
+		EffectClass, // 사용할 이펙트 클래스
+		GetAbilityLevel(), // 현재 어빌리티 레벨
+		ContextHandle // 위에서 만든 컨텍스트 정보
+	);
+
+	// SetByCaller 방식으로 데미지 값 설정 (이펙트 블루프린트에서 동적으로 받을 수 있음)
+	// TMap<FGameplayTag, float> SetByCallerTagMagnitudes; -> key: ShooterGamePlayTags::Shared_SetByCaller_BaseDamage, value: InWeaponBaseDamage
+	EffectSpecHandle.Data->SetSetByCallerMagnitude(
+		ShooterGamePlayTags::Shared_SetByCaller_BaseDamage,
+		InWeaponBaseDamage
+	);
+
+	// 완성된 이펙트 스펙 핸들을 반환 -> 이걸로 ApplyGameplayEffectToTarget() 같은 함수에 넘겨서 실제 적용함
+	return EffectSpecHandle;
 }

--- a/Source/Shooter/Private/AbilitySystem/GEExecCalculate/UGEExecCalculate_DamageTaken.cpp
+++ b/Source/Shooter/Private/AbilitySystem/GEExecCalculate/UGEExecCalculate_DamageTaken.cpp
@@ -1,0 +1,106 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "AbilitySystem/GEExecCalculate/UGEExecCalculate_DamageTaken.h"
+
+#include "ShooterGamePlayTag.h"
+#include "AbilitySystem/ShooterAttributeSet.h"
+
+struct FShooterDamageCapture
+{
+	DECLARE_ATTRIBUTE_CAPTUREDEF(AttackPower)
+	DECLARE_ATTRIBUTE_CAPTUREDEF(DefensePower)
+	DECLARE_ATTRIBUTE_CAPTUREDEF(DamageTaken)
+
+	FShooterDamageCapture()
+	{
+		DEFINE_ATTRIBUTE_CAPTUREDEF(UShooterAttributeSet, AttackPower, Source, false);
+		DEFINE_ATTRIBUTE_CAPTUREDEF(UShooterAttributeSet, DefensePower, Target, false);
+		DEFINE_ATTRIBUTE_CAPTUREDEF(UShooterAttributeSet, DamageTaken, Target, false);
+	}
+};
+
+static FShooterDamageCapture& GetShooterDamageCapture()
+{
+	static FShooterDamageCapture WarriorDamageCapture;
+	return WarriorDamageCapture;
+}
+
+UGEExecCalculate_DamageTaken::UGEExecCalculate_DamageTaken()
+{
+	RelevantAttributesToCapture.Add(GetShooterDamageCapture().AttackPowerDef);
+	RelevantAttributesToCapture.Add(GetShooterDamageCapture().DefensePowerDef);
+	RelevantAttributesToCapture.Add(GetShooterDamageCapture().DamageTakenDef);
+}
+
+void UGEExecCalculate_DamageTaken::Execute_Implementation(
+	const FGameplayEffectCustomExecutionParameters& ExecutionParams,
+	FGameplayEffectCustomExecutionOutput& OutExecutionOutput
+) const
+{
+	// 데미지를 받을 대상의 어빌리티 시스템 컴포넌트 GET
+	UAbilitySystemComponent* TargetAbilitySystemComponent = ExecutionParams.GetTargetAbilitySystemComponent();
+
+	if (TargetAbilitySystemComponent)
+	{
+		FGameplayTagContainer OwnedTags;
+		TargetAbilitySystemComponent->GetOwnedGameplayTags(OwnedTags);
+
+		// 태그들을 문자열로 출력
+		for (const FGameplayTag& Tag : OwnedTags)
+		{
+			UE_LOG(LogTemp, Warning, TEXT("보유 중인 태그: %s"), *Tag.ToString());
+		}
+	}
+
+	const FGameplayEffectSpec& EffectSpec = ExecutionParams.GetOwningSpec();
+
+	FAggregatorEvaluateParameters EvaluateParameters;
+	EvaluateParameters.SourceTags = EffectSpec.CapturedSourceTags.GetAggregatedTags();
+	EvaluateParameters.TargetTags = EffectSpec.CapturedTargetTags.GetAggregatedTags();
+
+	float SourceAttackPower = 0.f;
+
+	ExecutionParams.AttemptCalculateCapturedAttributeMagnitude(
+		GetShooterDamageCapture().AttackPowerDef,
+		EvaluateParameters,
+		SourceAttackPower
+	);
+
+	float BaseDamage = 0.f;
+	int32 UsedChargeAttackDamage = 0;
+
+	for (const TPair<FGameplayTag, float>& TagMagnitube : EffectSpec.SetByCallerTagMagnitudes)
+	{
+		const float MagnitudeValue = TagMagnitube.Value;
+		if (TagMagnitube.Key.MatchesTagExact(ShooterGamePlayTags::Shared_SetByCaller_BaseDamage))
+		{
+			BaseDamage = MagnitudeValue;
+			// Debug::Print(TEXT("BaseDamage"), BaseDamage);
+		}
+		if (TagMagnitube.Key.MatchesTagExact(ShooterGamePlayTags::Player_SetByCaller_AttackType_ChargeShoot))
+		{
+			UsedChargeAttackDamage = MagnitudeValue;
+		}
+	}
+
+	float TargetDefensePower = 0.f;
+	ExecutionParams.AttemptCalculateCapturedAttributeMagnitude(
+		GetShooterDamageCapture().DefensePowerDef,
+		EvaluateParameters,
+		TargetDefensePower
+	);
+
+	const float FinalDamageDone = BaseDamage * SourceAttackPower / TargetDefensePower;
+
+	if (FinalDamageDone > 0.f)
+	{
+		FGameplayModifierEvaluatedData ModifierEvaluatedData = FGameplayModifierEvaluatedData(
+			GetShooterDamageCapture().DamageTakenProperty,
+			EGameplayModOp::Override,
+			FinalDamageDone
+		);
+
+		OutExecutionOutput.AddOutputModifier(ModifierEvaluatedData);
+	}
+}

--- a/Source/Shooter/Private/AbilitySystem/ShooterAbilitySystemComponent.cpp
+++ b/Source/Shooter/Private/AbilitySystem/ShooterAbilitySystemComponent.cpp
@@ -2,6 +2,8 @@
 
 
 #include "AbilitySystem/ShooterAbilitySystemComponent.h"
+#include "AbilitySystem/Abilities/ShooterPlayerGameplayAbility.h"
+#include "Shooter/ShooterDebugHelper.h"
 
 /**
  * 능력 활성화 입력이 감지되었을 때 호출되는 메소드입니다.
@@ -22,6 +24,7 @@ void UShooterAbilitySystemComponent::OnAbilityInputPressed(const FGameplayTag& I
 		{
 			continue;
 		}
+		UE_LOG(LogTemp, Warning, TEXT("MATCH FOUND! Activating Ability for InputTag: %s"), *InputTag.ToString());
 		TryActivateAbility(AbilitySpec.Handle);
 	}
 }
@@ -47,4 +50,82 @@ void UShooterAbilitySystemComponent::OnAbilityInputReleased(const FGameplayTag& 
 			CancelAbilityHandle(AbilitySpec.Handle);
 		}
 	}
+}
+
+void UShooterAbilitySystemComponent::GrantShooterWeaponAbilities(
+	const TArray<FShooterAbilitySet>& InDefaultWeaponAbilities, int32 ApplyLevel,
+	TArray<FGameplayAbilitySpecHandle>& OutGrantedAbilitySpecHandles)
+{
+	if (InDefaultWeaponAbilities.IsEmpty())
+	{
+		return;
+	}
+	for (const FShooterAbilitySet& AbilitySet : InDefaultWeaponAbilities)
+	{
+		if (!AbilitySet.IsValid())
+		{
+			continue;
+		}
+		FGameplayAbilitySpec AbilitySpec(AbilitySet.AbilityToGrant);
+		AbilitySpec.SourceObject = GetAvatarActor();
+		AbilitySpec.Level = ApplyLevel;
+		AbilitySpec.GetDynamicSpecSourceTags().AddTag(AbilitySet.InputTag);
+
+		OutGrantedAbilitySpecHandles.AddUnique(GiveAbility(AbilitySpec));
+	}
+}
+
+void UShooterAbilitySystemComponent::RemoveGrantShooterWeaponAbilities(
+	TArray<FGameplayAbilitySpecHandle>& InSpecHandlesRemove)
+{
+	if (InSpecHandlesRemove.IsEmpty())
+	{
+		return;
+	}
+
+	for (const FGameplayAbilitySpecHandle& SpecHandle : InSpecHandlesRemove)
+	{
+		if (SpecHandle.IsValid())
+		{
+			ClearAbility(SpecHandle);
+		}
+	}
+
+	// 혹시모를 안전장치
+	InSpecHandlesRemove.Empty();
+}
+
+bool UShooterAbilitySystemComponent::TryActivateAbilityByTag(FGameplayTag AbilityTagToActivate)
+{
+	check(AbilityTagToActivate.IsValid());
+
+	// 해당 태그와 일치하는 활성화 가능한 어빌리티들을 담을 배열
+	TArray<FGameplayAbilitySpec*> FoundAbilitiesSpecs;
+
+	// AbilityTagToActivate와 일치하는 어빌리티들을 검색하여 FoundAbilitiesSpecs에 채운다
+	GetActivatableGameplayAbilitySpecsByAllMatchingTags(
+		AbilityTagToActivate.GetSingleTagContainer(), // 단일 태그 컨테이너로 변환
+		FoundAbilitiesSpecs
+	);
+
+	// 조건: 태그에 해당하는 어빌리티가 하나라도 있다면
+	if (!FoundAbilitiesSpecs.IsEmpty())
+	{
+		// 어빌리티가 여러 개일 수 있으므로, 무작위로 하나 선택
+		const int32 RandomAbilityIndex = FMath::RandRange(0, FoundAbilitiesSpecs.Num() - 1);
+		const FGameplayAbilitySpec* SpecToActivate = FoundAbilitiesSpecs[RandomAbilityIndex];
+
+		// 무작위로 선택된 어빌리티가 null이 아닌지 확인
+		check(SpecToActivate);
+
+		// 이미 활성화된 어빌리티가 아니라면
+		if (!SpecToActivate->IsActive())
+		{
+			// 해당 어빌리티를 활성화 시도하고 결과 반환
+			return TryActivateAbility(SpecToActivate->Handle);
+		}
+	}
+
+	// 어빌리티를 찾지 못했거나 이미 활성화된 경우 false 반환
+	return false;
 }

--- a/Source/Shooter/Private/Characters/ShooterBaseCharacter.cpp
+++ b/Source/Shooter/Private/Characters/ShooterBaseCharacter.cpp
@@ -20,7 +20,7 @@ AShooterBaseCharacter::AShooterBaseCharacter()
 
 UAbilitySystemComponent* AShooterBaseCharacter::GetAbilitySystemComponent() const
 {
-	return nullptr;
+	return GetShooterAbilitySystemComponent();
 }
 
 UPawnCombatComponent* AShooterBaseCharacter::GetPawnCombatComponent() const

--- a/Source/Shooter/Private/Characters/ShooterCharacter.cpp
+++ b/Source/Shooter/Private/Characters/ShooterCharacter.cpp
@@ -242,6 +242,10 @@ void AShooterCharacter::Input_Jump(const FInputActionValue& InputActionValue)
 	}
 }
 
+void AShooterCharacter::Input_Fire(const FInputActionValue& InputActionValue)
+{
+}
+
 void AShooterCharacter::Input_AbilityInputPressed(FGameplayTag InInputTag)
 {
 	ShooterAbilitySystemComponent->OnAbilityInputPressed(InInputTag);

--- a/Source/Shooter/Private/Components/Combat/PawnCombatComponent.cpp
+++ b/Source/Shooter/Private/Components/Combat/PawnCombatComponent.cpp
@@ -3,6 +3,41 @@
 
 #include "Components/Combat/PawnCombatComponent.h"
 #include "Items/Weapons/ShooterWeaponBase.h"
+#include "Shooter/ShooterDebugHelper.h"
+
+void UPawnCombatComponent::RegisterSpawnedWeapon(
+	FGameplayTag InWeaponTagToResister,
+	AShooterWeaponBase* InWeaponToResister,
+	bool bResisterAsEquippedWeapon
+)
+{
+	// 1. 이미 동일한 태그로 등록된 무기가 있는지 확인 (있으면 에러 발생)
+	checkf(
+		!CharacterCarriedWeaponMap.Contains(InWeaponTagToResister),
+		TEXT("%s는(은) 이미 장착된 무기 목록에 포함되어 있습니다"),
+		*InWeaponTagToResister.ToString()
+	);
+	// 2. 전달받은 무기 객체가 유효한지 확인 (nullptr이면 에러 발생)
+	check(InWeaponToResister);
+
+	const FString WeaponString = FString::Printf(
+		TEXT("무기이름: %s, 등록된 태그: %s"), *InWeaponToResister->GetName(), *InWeaponTagToResister.ToString());
+	Debug::Print(WeaponString);
+
+	// 3. 무기 태그와 무기 객체를 맵에 등록 (무기 보유 목록에 추가)
+	CharacterCarriedWeaponMap.Emplace(InWeaponTagToResister, InWeaponToResister);
+
+	// ~델리게이트 구독 (이 무기로 누군가를 맞추면 OnHitTargetActor 함수가 호출됨)
+	InWeaponToResister->OnWeaponHitTarget.BindUObject(this, &ThisClass::OnHitTargetActor);
+	InWeaponToResister->OnWeaponPulledFromTarget.BindUObject(this, &ThisClass::OnWeaponPulledFromTargetActor);
+	// ~델리게이트 구독
+
+	if (bResisterAsEquippedWeapon)
+	{
+		// 4. 현재 장착 무기 태그를 이번에 등록한 무기 태그로 갱신
+		CurrentEquippedWeaponTag = InWeaponTagToResister;
+	}
+}
 
 AShooterWeaponBase* UPawnCombatComponent::GetCharacterCarriedWeaponByTag(FGameplayTag InWeaponTagToGet) const
 {
@@ -22,4 +57,12 @@ AShooterWeaponBase* UPawnCombatComponent::GetCharacterCurrentEquippedWeapon() co
 	}
 	// 3. 유효한 태그가 있을 경우, 해당 태그로 등록된 무기를 찾아 반환
 	return GetCharacterCarriedWeaponByTag(CurrentEquippedWeaponTag);
+}
+
+void UPawnCombatComponent::OnHitTargetActor(AActor* HitActor)
+{
+}
+
+void UPawnCombatComponent::OnWeaponPulledFromTargetActor(AActor* InteractingActor)
+{
 }

--- a/Source/Shooter/Private/Components/Combat/ShooterCombatComponent.cpp
+++ b/Source/Shooter/Private/Components/Combat/ShooterCombatComponent.cpp
@@ -2,7 +2,35 @@
 
 
 #include "Components/Combat/ShooterCombatComponent.h"
+
+#include "AbilitySystemBlueprintLibrary.h"
+#include "Abilities/GameplayAbilityTypes.h"
 #include "Items/Weapons/ShooterPlayerWeapon.h"
+
+void UShooterCombatComponent::OnHitTargetActor(AActor* HitActor)
+{
+	// 공격때마다 1회만 공격처리
+	if (OverlappedActors.Contains(HitActor))
+	{
+		return;
+	}
+
+	OverlappedActors.AddUnique(HitActor);
+
+	FGameplayEventData EventData;
+	EventData.Instigator = GetOwningPawn();
+	EventData.Target = HitActor;
+
+	UAbilitySystemBlueprintLibrary::SendGameplayEventToActor(
+		GetOwningPawn(),
+		ShooterGamePlayTags::Shared_Event_Shoot,
+		EventData
+	);
+}
+
+void UShooterCombatComponent::OnWeaponPulledFromTargetActor(AActor* InteractingActor)
+{
+}
 
 AShooterPlayerWeapon* UShooterCombatComponent::GetHeroCurrentEquippedWeapon() const
 {
@@ -11,7 +39,12 @@ AShooterPlayerWeapon* UShooterCombatComponent::GetHeroCurrentEquippedWeapon() co
 	return ShooterWeapon ? ShooterWeapon : nullptr;
 }
 
-float UShooterCombatComponent::GetHeroCurrentEquippedWeaponDamageAtLevel(float InLevel) const
+AShooterPlayerWeapon* UShooterCombatComponent::GetShooterCarriedWeaponByTag(FGameplayTag InWeaponTag) const
 {
-	return GetHeroCurrentEquippedWeapon()->GetShooterWeaponData().WeaponBaseDamage.GetValueAtLevel(InLevel);
+	return Cast<AShooterPlayerWeapon>(GetCharacterCarriedWeaponByTag(InWeaponTag));
+}
+
+float UShooterCombatComponent::GetShooterCurrentEquippedWeaponDamageAtLevel(float InLevel) const
+{
+	return GetHeroCurrentEquippedWeapon()->ShooterWeaponData.WeaponBaseDamage.GetValueAtLevel(InLevel);
 }

--- a/Source/Shooter/Private/Components/Combat/ShooterEnemyCombatComponent.cpp
+++ b/Source/Shooter/Private/Components/Combat/ShooterEnemyCombatComponent.cpp
@@ -3,6 +3,28 @@
 
 #include "Components/Combat/ShooterEnemyCombatComponent.h"
 #include "AbilitySystemBlueprintLibrary.h"
+#include "ShooterGamePlayTag.h"
+
+void UShooterEnemyCombatComponent::OnHitTargetActor(AActor* HitActor)
+{
+	// 이미 겹친 액터(같은 프레임에서 중복 피격 방지)에 포함되어 있다면 리턴
+	if (OverlappedActors.Contains(HitActor))
+	{
+		return;
+	}
+
+	OverlappedActors.AddUnique(HitActor);
+
+	FGameplayEventData EventData;
+	EventData.Instigator = GetOwningPawn(); // 공격자 설정
+	EventData.Target = HitActor; // 피격 대상 설정
+
+	UAbilitySystemBlueprintLibrary::SendGameplayEventToActor(
+		GetOwningPawn(),
+		ShooterGamePlayTags::Shared_Event_Shoot,
+		EventData
+	);
+}
 
 void UShooterEnemyCombatComponent::TriggerGameplayEvent(
 	const FGameplayTag EventTag,

--- a/Source/Shooter/Private/DataAssets/StartUpDatas/DataAsset_ShooterStartUpData.cpp
+++ b/Source/Shooter/Private/DataAssets/StartUpDatas/DataAsset_ShooterStartUpData.cpp
@@ -2,4 +2,38 @@
 
 
 #include "DataAssets/StartUpDatas/DataAsset_ShooterStartUpData.h"
+#include "AbilitySystem/Abilities/ShooterPlayerGameplayAbility.h"
+#include "AbilitySystem/ShooterAbilitySystemComponent.h"
+#include "Shooter/ShooterDebugHelper.h"
 
+void UDataAsset_ShooterStartUpData::GiveToAbilitySystemComponent(
+	UShooterAbilitySystemComponent* InASCToGive,
+	int32 ApplyLevel
+)
+{
+	Super::GiveToAbilitySystemComponent(InASCToGive, ApplyLevel);
+	for (const FShooterAbilitySet& AbilitySet : ShooterStartUpAbilitySets)
+	{
+		if (!AbilitySet.IsValid())
+		{
+			continue;
+		}
+
+		FGameplayAbilitySpec AbilitySpec(AbilitySet.AbilityToGrant);
+		AbilitySpec.SourceObject = InASCToGive->GetAvatarActor();
+		AbilitySpec.Level = ApplyLevel;
+		AbilitySpec.GetDynamicSpecSourceTags().AddTag(AbilitySet.InputTag);
+
+		// 	const FString WeaponString = FString::Printf(
+		// TEXT("무기이름: %s, 등록된 태그: %s"), *InWeaponToResister->GetName(), *InWeaponTagToResister.ToString());
+		// 	Debug::Print(WeaponString);
+
+		const FString InputTagString =
+			FString::Printf(TEXT("AbilitySet.InputTag: %s"), *AbilitySet.InputTag.ToString());
+		//
+
+		Debug::Print(InputTagString);
+
+		InASCToGive->GiveAbility(AbilitySpec);
+	}
+}

--- a/Source/Shooter/Private/DataAssets/StartUpDatas/DataAsset_StartUpDataBase.cpp
+++ b/Source/Shooter/Private/DataAssets/StartUpDatas/DataAsset_StartUpDataBase.cpp
@@ -3,7 +3,8 @@
 
 #include "DataAssets/StartUpDatas/DataAsset_StartUpDataBase.h"
 #include "AbilitySystem/ShooterAbilitySystemComponent.h"
-#include "AbilitySystem/Abilities/ShooterGameplayAbility.h"
+#include "AbilitySystem/Abilities/ShooterPlayerGameplayAbility.h"
+#include "Shooter/ShooterDebugHelper.h"
 
 /**
  * 지정된 능력 시스템 컴포넌트(ASC)에 게임플레이 능력 및 효과를 부여합니다.

--- a/Source/Shooter/Private/Items/Weapons/ShooterPlayerWeapon.cpp
+++ b/Source/Shooter/Private/Items/Weapons/ShooterPlayerWeapon.cpp
@@ -13,7 +13,7 @@ TArray<FGameplayAbilitySpecHandle> AShooterPlayerWeapon::GetGrantedAbilitySpecHa
 	return GrantedAbilitySpecHandles;
 }
 
-const FWarriorHeroWeaponData& AShooterPlayerWeapon::GetShooterWeaponData() const
-{
-	return ShooterWeaponData;
-}
+// const FWarriorHeroWeaponData& AShooterPlayerWeapon::GetShooterWeaponData() const
+// {
+// 	return ShooterWeaponData;
+// }

--- a/Source/Shooter/Private/ShooterFunctionLibrary.cpp
+++ b/Source/Shooter/Private/ShooterFunctionLibrary.cpp
@@ -2,9 +2,21 @@
 
 
 #include "ShooterFunctionLibrary.h"
+
+#include "AbilitySystemBlueprintLibrary.h"
 #include "GameplayTagContainer.h"
 #include "ShooterGamePlayTag.h"
+#include "AbilitySystem/ShooterAbilitySystemComponent.h"
 #include "Kismet/KismetMathLibrary.h"
+
+UShooterAbilitySystemComponent* UShooterFunctionLibrary::NativeGetWarriorASCFromActor(AActor* InActor)
+{
+	check(InActor);
+
+	return CastChecked<UShooterAbilitySystemComponent>(
+		UAbilitySystemBlueprintLibrary::GetAbilitySystemComponent(InActor)
+	);
+}
 
 FGameplayTag UShooterFunctionLibrary::ComputeHitReactDirectionTag(
 	AActor* InAttacker,
@@ -37,6 +49,24 @@ FGameplayTag UShooterFunctionLibrary::ComputeHitReactDirectionTag(
 		OutAngleDifference *= -1.f;
 	}
 	return DetermineHitReactionTag(OutAngleDifference);
+}
+
+void UShooterFunctionLibrary::BP_DoesActorHaveTag(
+	AActor* InActor,
+	FGameplayTag TagToCheck,
+	EShooterConfirmType& OutConfirmType
+)
+{
+	OutConfirmType = NativeDoesActorHaveTag(InActor, TagToCheck)
+		                 ? EShooterConfirmType::ESC_Yes
+		                 : EShooterConfirmType::ESC_No;
+}
+
+bool UShooterFunctionLibrary::NativeDoesActorHaveTag(AActor* InActor, FGameplayTag TagToCheck)
+{
+	UShooterAbilitySystemComponent* ASC = NativeGetWarriorASCFromActor(InActor);
+
+	return ASC->HasMatchingGameplayTag(TagToCheck);
 }
 
 FGameplayTag UShooterFunctionLibrary::DetermineHitReactionTag(const float& OutAngleDifference)

--- a/Source/Shooter/Private/ShooterGamePlayTag.cpp
+++ b/Source/Shooter/Private/ShooterGamePlayTag.cpp
@@ -19,6 +19,9 @@ namespace ShooterGamePlayTags
 	UE_DEFINE_GAMEPLAY_TAG(InputTag_ConsumableItem_HealingItem, "InputTag.ConsumableItem.HealingItem");
 	UE_DEFINE_GAMEPLAY_TAG(InputTag_ConsumableItem_GrenadeItem, "InputTag.ConsumableItem.GrenadeItem");
 
+	UE_DEFINE_GAMEPLAY_TAG(InputTag_EquipWeapon, "InputTag.EquipWeapon");
+	UE_DEFINE_GAMEPLAY_TAG(InputTag_UnequipWeapon, "InputTag.UnequipWeapon");
+
 	/** Ability Tags**/
 	UE_DEFINE_GAMEPLAY_TAG(Player_Ability_Weapon_Equip, "Player.Ability.Weapon.Equip");
 	UE_DEFINE_GAMEPLAY_TAG(Player_Ability_Weapon_Fire, "Player.Ability.Weapon.Fire");
@@ -26,6 +29,22 @@ namespace ShooterGamePlayTags
 	UE_DEFINE_GAMEPLAY_TAG(Player_Ability_ConsumableItem_UseItemBase, "Player.Ability.ConsumableItem.UsetItemBase");
 	UE_DEFINE_GAMEPLAY_TAG(Player_Ability_ConsumableItem_HealingItem, "Player.Ability.ConsumableItem.HealingItem");
 	UE_DEFINE_GAMEPLAY_TAG(Player_Ability_ConsumableItem_GrenadeItem, "Player.Ability.ConsumableItem.GrenadeItem");
+
+	UE_DEFINE_GAMEPLAY_TAG(Player_Ability_Equip_Rifle, "Player.Ability.Equip.Rifle");
+	UE_DEFINE_GAMEPLAY_TAG(Player_Ability_Unequip_Rifle, "Player.Ability.Unequip.Rifle");
+	UE_DEFINE_GAMEPLAY_TAG(Player_Ability_Attack, "Player.Ability.Attack");
+
+	/* Weapon Tags */
+	UE_DEFINE_GAMEPLAY_TAG(Player_Weapon_Rifle, "Player.Weapon.Rifle");
+
+	/* SetByCaller Tags */
+	UE_DEFINE_GAMEPLAY_TAG(Player_SetByCaller_AttackType_Shoot, "Player.SetByCaller.AttackType.Shoot");
+	UE_DEFINE_GAMEPLAY_TAG(Player_SetByCaller_AttackType_ChargeShoot, "Player.SetByCaller.AttackType.ChargeShoot");
+
+	/*Event Tags*/
+	UE_DEFINE_GAMEPLAY_TAG(Player_Event_Equip_Rifle, "Player.Event.Equip.Rifle");
+	UE_DEFINE_GAMEPLAY_TAG(Player_Event_Unequip_Rifle, "Player.Event.Unequip.Rifle");
+
 	/* Shared */
 	UE_DEFINE_GAMEPLAY_TAG(Shared_Ability_Death, "Shared.Ability.Death");
 	UE_DEFINE_GAMEPLAY_TAG(Shared_Ability_HitReact, "Shared.Ability.HitReact");
@@ -36,4 +55,10 @@ namespace ShooterGamePlayTags
 	UE_DEFINE_GAMEPLAY_TAG(Shared_Status_HitReact_Right, "Shared.Status.HitReact.Right");
 
 	UE_DEFINE_GAMEPLAY_TAG(Shared_Data_ReloadAmount, "Shared.Data.ReloadAmount");
+
+	UE_DEFINE_GAMEPLAY_TAG(Shared_Event_HitReact, "Shared.Event.HitReact");
+	UE_DEFINE_GAMEPLAY_TAG(Shared_Event_Shoot, "Shared.Event.Shoot");
+
+	UE_DEFINE_GAMEPLAY_TAG(Shared_SetByCaller_BaseDamage, "Shared.SetByCaller.BaseDamage");
+	UE_DEFINE_GAMEPLAY_TAG(Shared_SetByCaller_ChargeShootDamage, "Shared.SetByCaller.ChargeShootDamage");
 }

--- a/Source/Shooter/Private/ShooterTypes/ShooterStructTypes.cpp
+++ b/Source/Shooter/Private/ShooterTypes/ShooterStructTypes.cpp
@@ -2,7 +2,7 @@
 
 
 #include "ShooterTypes/ShooterStructTypes.h"
-#include "AbilitySystem/Abilities/ShooterGameplayAbility.h"
+#include "AbilitySystem/Abilities/ShooterPlayerGameplayAbility.h"
 
 bool FShooterAbilitySet::IsValid() const
 {

--- a/Source/Shooter/Public/AbilitySystem/Abilities/ShooterGameplayAbility.h
+++ b/Source/Shooter/Public/AbilitySystem/Abilities/ShooterGameplayAbility.h
@@ -4,8 +4,12 @@
 
 #include "CoreMinimal.h"
 #include "Abilities/GameplayAbility.h"
+#include "ShooterTypes/ShooterEnumTypes.h"
 #include "ShooterGameplayAbility.generated.h"
 
+
+class UPawnCombatComponent;
+class UShooterAbilitySystemComponent;
 
 UENUM(BlueprintType)
 enum class EShooterAbilityActivationPolicy : uint8
@@ -25,22 +29,13 @@ class SHOOTER_API UShooterGameplayAbility : public UGameplayAbility
 {
 	GENERATED_BODY()
 
+protected:
+	UPROPERTY(EditAnywhere, Category = "Shooter|Ability")
+	EShooterAbilityActivationPolicy AbilityActivationPolicy = EShooterAbilityActivationPolicy::EWA_OnTriggered;
+
 	// ~ Begin UGameplayAbility Interface.
-	/**
-	 * 이 어빌리티가 액터(예: 캐릭터)에게 부여될 때 호출됩니다.
-	 * @param ActorInfo    어빌리티가 부여된 액터에 대한 정보입니다.
-	 * @param Spec         어빌리티의 사양(레벨, 입력 바인딩 등)을 담고 있는 구조체입니다.
-	 */
 	virtual void OnGiveAbility(const FGameplayAbilityActorInfo* ActorInfo, const FGameplayAbilitySpec& Spec) override;
 
-	/**
-	 * 어빌리티가 종료될 때 호출됩니다. 종료 원인은 정상적인 종료 또는 취소일 수 있습니다.
-	 * @param Handle               어빌리티를 식별하기 위한 핸들입니다.
-	 * @param ActorInfo            어빌리티를 가진 액터에 대한 정보입니다.
-	 * @param ActivationInfo       어빌리티가 어떻게 활성화되었는지에 대한 정보입니다.
-	 * @param bReplicateEndAbility true이면, 어빌리티 종료 정보를 네트워크를 통해 클라이언트에도 전파합니다.
-	 * @param bWasCancelled        true이면, 어빌리티가 중간에 취소되어 종료된 것입니다.
-	 */
 	virtual void EndAbility(
 		const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo,
 		const FGameplayAbilityActivationInfo ActivationInfo, bool bReplicateEndAbility,
@@ -48,7 +43,25 @@ class SHOOTER_API UShooterGameplayAbility : public UGameplayAbility
 	) override;
 	// ~ End UGameplayAbility Interface.
 
-protected:
-	UPROPERTY(EditAnywhere, Category = "WarriorAbility")
-	EShooterAbilityActivationPolicy AbilityActivationPolicy = EShooterAbilityActivationPolicy::EWA_OnTriggered;
+	UFUNCTION(BlueprintPure, Category = "Shooter|Ability")
+	UPawnCombatComponent* GetPawnCombatComponentFromActorInfo() const;
+
+	FActiveGameplayEffectHandle NativeApplyEffectSpecHandleToTarget(
+		AActor* TargetActor,
+		const FGameplayEffectSpecHandle& InSpecHandle
+	);
+
+	UFUNCTION(BlueprintPure, Category = "Shooter|Ability")
+	UShooterAbilitySystemComponent* GetShooterAbilitySystemComponentFromActorInfo() const;
+
+	UFUNCTION(
+		BlueprintCallable,
+		Category = "Shooter|Ability",
+		meta = (DisplayName = "Apply Gameplay Effect Spec Handle To Target Actor", ExpandEnumAsExecs = "OutSuccessType")
+	)
+	FActiveGameplayEffectHandle BP_ApplyEffectSpecHandleToTarget(
+		AActor* TargetActor,
+		const FGameplayEffectSpecHandle& InSpecHandle,
+		EShooterSuccessType& OutSuccessType
+	);
 };

--- a/Source/Shooter/Public/AbilitySystem/Abilities/ShooterPlayerGameplayAbility.h
+++ b/Source/Shooter/Public/AbilitySystem/Abilities/ShooterPlayerGameplayAbility.h
@@ -27,6 +27,13 @@ public:
 	UFUNCTION(BlueprintPure, Category = "Shooter|Ability")
 	UShooterCombatComponent* GetShooterCombatComponentFromActorInfo();
 
+	UFUNCTION(BlueprintPure, Category = "Warrior|Ability")
+	FGameplayEffectSpecHandle MakeShooterDamageEffectSpecHandle(
+		TSubclassOf<UGameplayEffect> EffectClass,
+		float InWeaponBaseDamage,
+		FGameplayTag InCurrentAttackTypeTag
+	);
+
 private:
 	TWeakObjectPtr<AShooterCharacter> CachedShooterCharacter;
 	TWeakObjectPtr<AShooterController> CachedShooterController;

--- a/Source/Shooter/Public/AbilitySystem/GEExecCalculate/UGEExecCalculate_DamageTaken.h
+++ b/Source/Shooter/Public/AbilitySystem/GEExecCalculate/UGEExecCalculate_DamageTaken.h
@@ -1,0 +1,24 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayEffectExecutionCalculation.h"
+#include "UGEExecCalculate_DamageTaken.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class SHOOTER_API UGEExecCalculate_DamageTaken : public UGameplayEffectExecutionCalculation
+{
+	GENERATED_BODY()
+
+public:
+	UGEExecCalculate_DamageTaken();
+
+	virtual void Execute_Implementation(
+		const FGameplayEffectCustomExecutionParameters& ExecutionParams,
+		FGameplayEffectCustomExecutionOutput& OutExecutionOutput
+	) const override;
+};

--- a/Source/Shooter/Public/AbilitySystem/ShooterAbilitySystemComponent.h
+++ b/Source/Shooter/Public/AbilitySystem/ShooterAbilitySystemComponent.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "AbilitySystemComponent.h"
+#include "ShooterTypes/ShooterStructTypes.h"
 #include "ShooterAbilitySystemComponent.generated.h"
 
 /**
@@ -17,4 +18,20 @@ class SHOOTER_API UShooterAbilitySystemComponent : public UAbilitySystemComponen
 public:
 	void OnAbilityInputPressed(const FGameplayTag& InputTag);
 	void OnAbilityInputReleased(const FGameplayTag& InputTag);
+
+	UFUNCTION(BlueprintCallable, Category = "Shooter|Ability", meta = (ApplyLevel = "1"))
+	void GrantShooterWeaponAbilities(
+		const TArray<FShooterAbilitySet>& InDefaultWeaponAbilities,
+		int32 ApplyLevel,
+		TArray<FGameplayAbilitySpecHandle>& OutGrantedAbilitySpecHandles
+	);
+
+	UFUNCTION(BlueprintCallable, Category = "Shooter|Ability")
+	void RemoveGrantShooterWeaponAbilities(
+		UPARAM(ref)
+		TArray<FGameplayAbilitySpecHandle>& InSpecHandlesRemove
+	);
+
+	UFUNCTION(BlueprintCallable, Category = "Shooter|Ability")
+	bool TryActivateAbilityByTag(FGameplayTag AbilityTagToActivate);
 };

--- a/Source/Shooter/Public/Characters/ShooterBaseCharacter.h
+++ b/Source/Shooter/Public/Characters/ShooterBaseCharacter.h
@@ -57,4 +57,6 @@ public:
 	{
 		return ShooterAbilitySystemComponent;
 	}
+
+	FORCEINLINE UShooterAttributeSet* GetWarriorAttributeSet() const { return ShooterAttributeSet; }
 };

--- a/Source/Shooter/Public/Characters/ShooterCharacter.h
+++ b/Source/Shooter/Public/Characters/ShooterCharacter.h
@@ -59,6 +59,7 @@ private:
 	void Input_Walk(const FInputActionValue& InputActionValue);
 	void Input_Sprint(const FInputActionValue& InputActionValue);
 	void Input_Jump(const FInputActionValue& InputActionValue);
+	void Input_Fire(const FInputActionValue& InputActionValue);
 
 	void Input_AbilityInputPressed(FGameplayTag InInputTag);
 	void Input_AbilityInputReleased(FGameplayTag InInputTag);

--- a/Source/Shooter/Public/Components/Combat/PawnCombatComponent.h
+++ b/Source/Shooter/Public/Components/Combat/PawnCombatComponent.h
@@ -17,6 +17,12 @@ class SHOOTER_API UPawnCombatComponent : public UPawnExtensionComponentBase
 	GENERATED_BODY()
 
 public:
+	UFUNCTION(BlueprintCallable, Category = "Shooter|Combat")
+	void RegisterSpawnedWeapon(
+		FGameplayTag InWeaponTagToResister,
+		AShooterWeaponBase* InWeaponToResister,
+		bool bResisterAsEquippedWeapon = false
+	);
 	/**
 	 * 특정 무기를 검색할 수 있다.
 	 * @param InWeaponTagToGet FGameplayTag
@@ -36,6 +42,13 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Shooter|Combat")
 	AShooterWeaponBase* GetCharacterCurrentEquippedWeapon() const;
+
+	virtual void OnHitTargetActor(AActor* HitActor);
+	virtual void OnWeaponPulledFromTargetActor(AActor* InteractingActor);
+
+protected:
+	UPROPERTY()
+	TArray<AActor*> OverlappedActors;
 
 private:
 	UPROPERTY()

--- a/Source/Shooter/Public/Components/Combat/ShooterCombatComponent.h
+++ b/Source/Shooter/Public/Components/Combat/ShooterCombatComponent.h
@@ -16,9 +16,15 @@ class SHOOTER_API UShooterCombatComponent : public UPawnCombatComponent
 	GENERATED_BODY()
 
 public:
+	virtual void OnHitTargetActor(AActor* HitActor) override;
+	virtual void OnWeaponPulledFromTargetActor(AActor* InteractingActor) override;
+
 	UFUNCTION(BlueprintCallable, Category = "Shooter|Combat")
 	AShooterPlayerWeapon* GetHeroCurrentEquippedWeapon() const;
 
+	UFUNCTION(BlueprintCallable, Category = "Warrior|Combat")
+	AShooterPlayerWeapon* GetShooterCarriedWeaponByTag(FGameplayTag InWeaponTag) const;
+
 	UFUNCTION(BlueprintCallable, Category = "Shooter|Combat")
-	float GetHeroCurrentEquippedWeaponDamageAtLevel(float InLevel) const;
+	float GetShooterCurrentEquippedWeaponDamageAtLevel(float InLevel) const;
 };

--- a/Source/Shooter/Public/Components/Combat/ShooterEnemyCombatComponent.h
+++ b/Source/Shooter/Public/Components/Combat/ShooterEnemyCombatComponent.h
@@ -15,6 +15,9 @@ class SHOOTER_API UShooterEnemyCombatComponent : public UPawnCombatComponent
 {
 	GENERATED_BODY()
 
-	// public, protected, private이 없으면 암묵적으로 "private" 화 됨
+public:
+	virtual void OnHitTargetActor(AActor* HitActor) override;
+
+private:
 	void TriggerGameplayEvent(const FGameplayTag EventTag, const FGameplayEventData& EventData);
 };

--- a/Source/Shooter/Public/DataAssets/StartUpDatas/DataAsset_ShooterStartUpData.h
+++ b/Source/Shooter/Public/DataAssets/StartUpDatas/DataAsset_ShooterStartUpData.h
@@ -4,8 +4,10 @@
 
 #include "CoreMinimal.h"
 #include "DataAssets/StartUpDatas/DataAsset_StartUpDataBase.h"
+#include "ShooterTypes/ShooterStructTypes.h"
 #include "DataAsset_ShooterStartUpData.generated.h"
 
+// struct FShooterAbilitySet;
 /**
  * 
  */
@@ -13,5 +15,12 @@ UCLASS()
 class SHOOTER_API UDataAsset_ShooterStartUpData : public UDataAsset_StartUpDataBase
 {
 	GENERATED_BODY()
-	
+
+public:
+	virtual void
+	GiveToAbilitySystemComponent(UShooterAbilitySystemComponent* InASCToGive, int32 ApplyLevel = 1) override;
+
+private:
+	UPROPERTY(EditDefaultsOnly, Category = "StartUpData", meta = (TitleProperty = "InputTag"))
+	TArray<FShooterAbilitySet> ShooterStartUpAbilitySets;
 };

--- a/Source/Shooter/Public/Items/Weapons/ShooterPlayerWeapon.h
+++ b/Source/Shooter/Public/Items/Weapons/ShooterPlayerWeapon.h
@@ -35,22 +35,12 @@ public:
 	TArray<FGameplayAbilitySpecHandle> GetGrantedAbilitySpecHandles() const;
 
 	/**
-	 * 이 무기의 데이터 정보를 반환합니다.
-	 * 블루프린트 및 C++ 모두에서 읽기 전용으로 사용 가능합니다.
-	 *
-	 * @return 무기의 데이터 구조체
-	 */
-	UFUNCTION(BlueprintPure)
-	const FWarriorHeroWeaponData& GetShooterWeaponData() const;
-
-protected:
-	/**
 	 * 이 무기의 기본 정보 데이터입니다.
 	 * 데미지, 공격 속도, 부여할 어빌리티 목록 등을 포함합니다.
 	 * 블루프린트에서 읽을 수 있으나, 외부 C++ 클래스에서는 직접 접근할 수 없습니다.
 	 */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "WeaponData")
-	FWarriorHeroWeaponData ShooterWeaponData;
+	FShooterPlayerWeaponData ShooterWeaponData;
 
 private:
 	/**

--- a/Source/Shooter/Public/Items/Weapons/ShooterWeaponBase.h
+++ b/Source/Shooter/Public/Items/Weapons/ShooterWeaponBase.h
@@ -10,6 +10,8 @@
 class UShooterGameplayAbility;
 class UWeaponAttributeSet;
 
+DECLARE_DELEGATE_OneParam(FonTargetInteractedDelegate, AActor*)
+
 UCLASS()
 class SHOOTER_API AShooterWeaponBase : public AActor
 {
@@ -25,6 +27,9 @@ public:
 	// 무기 소유자에게 어빌리티 부여
 	UFUNCTION(BlueprintCallable, Category = "Weapon")
 	void GiveAbilityToOwner(AActor* NewOwner);
+
+	FonTargetInteractedDelegate OnWeaponHitTarget;
+	FonTargetInteractedDelegate OnWeaponPulledFromTarget;
 
 protected:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Abilities")

--- a/Source/Shooter/Public/ShooterFunctionLibrary.h
+++ b/Source/Shooter/Public/ShooterFunctionLibrary.h
@@ -4,9 +4,11 @@
 
 #include "CoreMinimal.h"
 #include "Kismet/BlueprintFunctionLibrary.h"
+#include "ShooterTypes/ShooterEnumTypes.h"
 #include "ShooterFunctionLibrary.generated.h"
 
 struct FGameplayTag;
+class UShooterAbilitySystemComponent;
 
 /**
  * 
@@ -17,8 +19,19 @@ class SHOOTER_API UShooterFunctionLibrary : public UBlueprintFunctionLibrary
 	GENERATED_BODY()
 
 public:
+	static UShooterAbilitySystemComponent* NativeGetWarriorASCFromActor(AActor* InActor);
+
 	UFUNCTION(BlueprintPure, Category = "Shooter|FunctionLibrary")
 	static FGameplayTag ComputeHitReactDirectionTag(AActor* InAttacker, AActor* InVictim, float& OutAngleDifference);
+
+	UFUNCTION(
+		BlueprintCallable,
+		Category = "Shooter|FunctionLibrary",
+		meta = (DisplayName = "Does Actor Have Tag", ExpandEnumAsExecs = "OutConfirmType")
+	)
+	static void BP_DoesActorHaveTag(AActor* InActor, FGameplayTag TagToCheck, EShooterConfirmType& OutConfirmType);
+
+	static bool NativeDoesActorHaveTag(AActor* InActor, FGameplayTag TagToCheck);
 
 private:
 	static FGameplayTag DetermineHitReactionTag(const float& OutAngleDifference);

--- a/Source/Shooter/Public/ShooterGamePlayTag.h
+++ b/Source/Shooter/Public/ShooterGamePlayTag.h
@@ -19,7 +19,9 @@ namespace ShooterGamePlayTags
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(InputTag_ConsumableItem_UseItemBase);
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(InputTag_ConsumableItem_HealingItem);
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(InputTag_ConsumableItem_GrenadeItem);
-	
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(InputTag_EquipWeapon);
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(InputTag_UnequipWeapon);
+
 	/** Ability Tags**/
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_Ability_Weapon_Equip);
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_Ability_Weapon_Fire);
@@ -27,12 +29,26 @@ namespace ShooterGamePlayTags
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_Ability_ConsumableItem_UseItemBase);
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_Ability_ConsumableItem_HealingItem);
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_Ability_ConsumableItem_GrenadeItem);
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_Ability_Equip_Rifle);
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_Ability_Unequip_Rifle);
 
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_Ability_Attack);
+
+	/* Weapon Tags */
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_Weapon_Rifle);
+
+	/* SetByCaller Tags */
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_SetByCaller_AttackType_Shoot);
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_SetByCaller_AttackType_ChargeShoot);
+
+	/*Event Tags*/
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_Event_Equip_Rifle);
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Player_Event_Unequip_Rifle);
 
 	/* Shared */
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Ability_Death);
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Ability_HitReact);
-	
+
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Status_HitReact_Front);
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Status_HitReact_Left);
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Status_HitReact_Back);
@@ -40,4 +56,9 @@ namespace ShooterGamePlayTags
 
 	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Data_ReloadAmount);
 
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Event_HitReact);
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_Event_Shoot);
+
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_SetByCaller_BaseDamage);
+	SHOOTER_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(Shared_SetByCaller_ChargeShootDamage);
 }

--- a/Source/Shooter/Public/ShooterTypes/ShooterEnumTypes.h
+++ b/Source/Shooter/Public/ShooterTypes/ShooterEnumTypes.h
@@ -1,0 +1,15 @@
+﻿#pragma once
+
+UENUM()
+enum class EShooterConfirmType : uint8
+{
+	ESC_Yes,
+	ESC_No,
+};
+
+UENUM()
+enum class EShooterSuccessType : uint8
+{
+	ESC_Successful,
+	ESC_Failed,
+};

--- a/Source/Shooter/Public/ShooterTypes/ShooterStructTypes.h
+++ b/Source/Shooter/Public/ShooterTypes/ShooterStructTypes.h
@@ -6,8 +6,8 @@
 #include "ScalableFloat.h"
 #include "ShooterStructTypes.generated.h"
 
+class UShooterPlayerGameplayAbility;
 class UInputMappingContext;
-class UShooterGameplayAbility;
 class UShooterLinkedAnimLayer;
 
 USTRUCT(BlueprintType)
@@ -19,13 +19,13 @@ struct FShooterAbilitySet
 	FGameplayTag InputTag;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	TSubclassOf<UShooterGameplayAbility> AbilityToGrant;
+	TSubclassOf<UShooterPlayerGameplayAbility> AbilityToGrant;
 
 	bool IsValid() const;
 };
 
 USTRUCT(BlueprintType)
-struct FWarriorHeroWeaponData
+struct FShooterPlayerWeaponData
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
UShooterAbilitySystemComponent를 통해 무기 능력을 부여하고 제거하는 시스템을 구현했습니다. 피해 계산을 위해 UGEExecCalculate_DamageTaken을 도입했으며, 능력 분류를 보다 명확히 하기 위해 게임플레이 태그를 확장했습니다. 추가로 유틸리티 함수와 무기 관련 위임(delegate) 기능도 함께 추가되었습니다.